### PR TITLE
Update nanoCLR_DataType enum

### DIFF
--- a/source/MetadataProcessor.Core/Utility/nanoCLR_DataType.cs
+++ b/source/MetadataProcessor.Core/Utility/nanoCLR_DataType.cs
@@ -1,4 +1,4 @@
-﻿//
+//
 // Copyright (c) 2019 The nanoFramework project contributors
 // Original work from Oleg Rakhmatulin.
 // See LICENSE file in the project root for full license information.
@@ -30,6 +30,16 @@ namespace nanoFramework.Tools.MetadataProcessor
         DATATYPE_DATETIME, // 8 bytes     // Shortcut for System.DateTime
         DATATYPE_TIMESPAN, // 8 bytes     // Shortcut for System.TimeSpan
         DATATYPE_STRING,
+
+        // This is the last type that doesn't need to be relocated
+        DATATYPE_LAST_NONPOINTER = DATATYPE_TIMESPAN,
+        // All the above types don't need fix-up on assignment
+        DATATYPE_LAST_PRIMITIVE_TO_PRESERVE = DATATYPE_R8,
+        // All the above types can be marshaled by assignment.
+        DATATYPE_LAST_PRIMITIVE_TO_MARSHAL = DATATYPE_TIMESPAN,
+
+        // All the above types don't need fix-up on assignment.
+        DATATYPE_LAST_PRIMITIVE = DATATYPE_STRING,
 
         DATATYPE_OBJECT, // Shortcut for System.Object
         DATATYPE_CLASS, // CLASS <class Token>


### PR DESCRIPTION
- Add missing entries to the enum to have an exact match with C++ `enum CLR_DataType`.