### PR TITLE
Add skeleton generator

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,7 +145,7 @@ jobs:
       nuGetFeedType: external
       packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
       publishFeedCredentials: 'AzureArtifacts'
-      continueOnError: true
+    continueOnError: true
     condition: succeeded()
     displayName: Push NuGet packages to Azure Artifacts
 

--- a/source/MetadataProcessor.Console/MetadataProcessor.Console.csproj
+++ b/source/MetadataProcessor.Console/MetadataProcessor.Console.csproj
@@ -35,6 +35,7 @@
     <Reference Include="Costura, Version=3.3.3.0, Culture=neutral, PublicKeyToken=9919ef960d84173d, processorArchitecture=MSIL">
       <HintPath>..\packages\Costura.Fody.3.3.3\lib\net40\Costura.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>

--- a/source/MetadataProcessor.Core/Extensions/TypeDefinitionExtensions.cs
+++ b/source/MetadataProcessor.Core/Extensions/TypeDefinitionExtensions.cs
@@ -1,0 +1,33 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using Mono.Cecil;
+
+namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
+{
+    internal static class TypeDefinitionExtensions
+    {
+        public static bool IncludeInStub(this TypeDefinition value)
+        {
+            var typeDefFlags = nanoTypeDefinitionTable.GetFlags(value);
+
+            if (typeDefFlags.HasFlag(
+                nanoTypeDefinitionFlags.TD_Delegate |
+                nanoTypeDefinitionFlags.TD_MulticastDelegate))
+            {
+                return false;
+            }
+
+            // Only generate a stub for classes and value types.
+            if (value.IsClass ||
+                value.IsValueType)
+            { 
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/source/MetadataProcessor.Core/MetadataProcessor.Core.csproj
+++ b/source/MetadataProcessor.Core/MetadataProcessor.Core.csproj
@@ -33,6 +33,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Cecil, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.dll</HintPath>
     </Reference>
@@ -45,17 +46,34 @@
     <Reference Include="Mono.Cecil.Rocks, Version=0.11.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <HintPath>..\packages\Mono.Cecil.0.11.1\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
+    <Reference Include="Stubble.Core, Version=1.6.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Stubble.Core.1.6.3\lib\net45\Stubble.Core.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Drawing" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.1\lib\netstandard2.0\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Endianness\nanoBinaryWriter.cs" />
+    <Compile Include="Extensions\TypeDefinitionExtensions.cs" />
     <Compile Include="InanoTable.cs" />
     <Compile Include="Mono.Cecil\CodeWriter.cs" />
     <Compile Include="nanoAssemblyBuilder.cs" />
     <Compile Include="nanoAssemblyDefinition.cs" />
+    <Compile Include="nanoSkeletonGenerator.cs" />
+    <Compile Include="SkeletonGenerator\AssemblyClass.cs" />
+    <Compile Include="SkeletonGenerator\AssemblyClassStubs.cs" />
+    <Compile Include="SkeletonGenerator\AssemblyLookupTable.cs" />
     <Compile Include="Tables\ICustomStringSorter.cs" />
     <Compile Include="Tables\nanoAssemblyReferenceTable.cs" />
     <Compile Include="Tables\nanoAttributesTable.cs" />
@@ -82,13 +100,16 @@
     <Compile Include="Utility\nanoCLR_DataType.cs" />
     <Compile Include="Utility\nanoFontProcessor.cs" />
     <Compile Include="Utility\nanoPdbxFileWriter.cs" />
+    <Compile Include="Utility\nanoTypeDefinitionFlags.cs" />
     <Compile Include="Utility\nanoSerializationType.cs" />
     <Compile Include="Utility\nanoStringsConstants.cs" />
     <Compile Include="Utility\NativeMethodsCrc.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <Compile Include="SkeletonGenerator\SkeletonTemplates.cs" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="..\packages\Nerdbank.GitVersioning.3.0.28\build\Nerdbank.GitVersioning.targets" Condition="Exists('..\packages\Nerdbank.GitVersioning.3.0.28\build\Nerdbank.GitVersioning.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/source/MetadataProcessor.Core/SkeletonGenerator/AssemblyClass.cs
+++ b/source/MetadataProcessor.Core/SkeletonGenerator/AssemblyClass.cs
@@ -1,0 +1,47 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+
+namespace nanoFramework.Tools.MetadataProcessor.Core
+{
+    public class AssemblyDeclaration
+    {
+        public string Name;
+        public string ShortName;
+        public string ShortNameUpper;
+
+        public List<Class> Classes = new List<Class>();
+    }
+
+    public class Class
+    {
+        public string Name;
+        public string AssemblyName;
+
+        public List<StaticField> StaticFields = new List<StaticField>();
+        public List<InstanceField> InstanceFields = new List<InstanceField>();
+        public List<Method> Methods = new List<Method>();
+    }
+
+    public class StaticField
+    {
+        public string Name;
+        public int ReferenceIndex;
+    }
+
+    public class InstanceField
+    {
+        public string Name;
+        public int ReferenceIndex;
+
+        public string FieldWarning;
+    }
+
+    public class Method
+    {
+        public string Declaration;
+    }
+}

--- a/source/MetadataProcessor.Core/SkeletonGenerator/AssemblyClassStubs.cs
+++ b/source/MetadataProcessor.Core/SkeletonGenerator/AssemblyClassStubs.cs
@@ -1,0 +1,16 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Collections.Generic;
+
+namespace nanoFramework.Tools.MetadataProcessor.Core
+{
+    public class AssemblyClassStubs
+    {
+        public string HeaderFileName;
+
+        public List<Method> Functions = new List<Method>();
+    }
+}

--- a/source/MetadataProcessor.Core/SkeletonGenerator/AssemblyLookupTable.cs
+++ b/source/MetadataProcessor.Core/SkeletonGenerator/AssemblyLookupTable.cs
@@ -1,0 +1,22 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+using System.Collections.Generic;
+
+namespace nanoFramework.Tools.MetadataProcessor.Core
+{
+    public class AssemblyLookupTable
+    {
+        public string Name;
+        public string AssemblyName;
+        public string HeaderFileName;
+        public string NativeCRC32;
+
+        public Version NativeVersion;
+
+        public List<Method> LookupTable = new List<Method>();
+    }
+}

--- a/source/MetadataProcessor.Core/SkeletonGenerator/SkeletonTemplates.cs
+++ b/source/MetadataProcessor.Core/SkeletonGenerator/SkeletonTemplates.cs
@@ -1,0 +1,108 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace nanoFramework.Tools.MetadataProcessor
+{
+    internal partial class SkeletonTemplates
+    {
+        internal static string AssemblyHeaderTemplate = 
+@"//-----------------------------------------------------------------------------
+//
+//                   ** WARNING! ** 
+//    This file was generated automatically by a tool.
+//    Re-running the tool will overwrite this file.
+//    You should copy this file to a custom location
+//    before adding any customization in the copy to
+//    prevent loss of your changes when the tool is
+//    re-run.
+//
+//-----------------------------------------------------------------------------
+
+#ifndef _{{ShortNameUpper}}_H_
+#define _{{ShortNameUpper}}_H_
+
+#include <nanoCLR_Interop.h>
+#include <nanoCLR_Runtime.h>
+#include <corlib_native.h>
+
+{{#Classes}}
+struct Library_{{AssemblyName}}_{{Name}}
+{
+	{{#StaticFields}}
+    static const int FIELD_STATIC__{{Name}} = {{ReferenceIndex}};
+	{{/StaticFields}}
+	{{#InstanceFields}}
+		{{#FieldWarning}}
+		{{FieldWarning}}
+		{{/FieldWarning}}
+    static const int FIELD__{{Name}} = {{ReferenceIndex}};
+	{{/InstanceFields}}
+
+	{{#Methods}}
+    NANOCLR_NATIVE_DECLARE({{Declaration}});
+	{{/Methods}}
+
+    //--//
+
+};
+
+{{/Classes}}
+
+extern const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_{{Name}};
+
+#endif  //_{{ShortNameUpper}}_H_
+";
+
+        internal static string AssemblyLookupTemplate =
+@"#include ""{{HeaderFileName}}.h\""
+
+static const CLR_RT_MethodHandler method_lookup[] =
+{
+{{#LookupTable}}
+    {{Declaration}},
+{{/LookupTable}}
+};
+
+const CLR_RT_NativeAssemblyData g_CLR_AssemblyNative_{{AssemblyName}} =
+{
+    ""{{Name}}"",
+    {{NativeCRC32}},
+    method_lookup,
+    ////////////////////////////////////////////////////////////////////////////////////
+    // check if the version bellow matches the one in AssemblyNativeVersion attribute //
+    ////////////////////////////////////////////////////////////////////////////////////
+    { {{NativeVersion.Major}}, {{NativeVersion.Minor}}, {{NativeVersion.Revision}}, {{NativeVersion.Build}} }
+};
+";
+
+        internal static string ClassStubTemplate =
+@"//-----------------------------------------------------------------------------
+//
+//                   ** WARNING! ** 
+//    This file was generated automatically by a tool.
+//    Re-running the tool will overwrite this file.
+//    You should copy this file to a custom location
+//    before adding any customization in the copy to
+//    prevent loss of your changes when the tool is
+//    re-run.
+//
+//-----------------------------------------------------------------------------
+
+#include ""{{HeaderFileName}}.h\""
+
+{{#Functions}}
+HRESULT {{Declaration}}( CLR_RT_StackFrame& stack )
+{
+    NANOCLR_HEADER();
+
+    NANOCLR_SET_AND_LEAVE(stack.NotImplementedStub());
+
+    NANOCLR_NOCLEANUP();
+}
+
+{{/Functions}}
+";
+    }
+}

--- a/source/MetadataProcessor.Core/Tables/nanoByteCodeTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoByteCodeTable.cs
@@ -78,7 +78,6 @@ namespace nanoFramework.Tools.MetadataProcessor
             var rva = method.HasBody ? _lastAvailableRva : (ushort)0xFFFF;
             var id = (ushort)_methods.Count;
 
-            _context.NativeMethodsCrc.UpdateCrc(method);
             var byteCode = CreateByteCode(method);
 
             _methods.Add(method);

--- a/source/MetadataProcessor.Core/Tables/nanoFieldDefinitionTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoFieldDefinitionTable.cs
@@ -84,13 +84,6 @@ namespace nanoFramework.Tools.MetadataProcessor
             bool trackMaxReferenceId,
             out ushort referenceId)
         {
-            // compare against classes to exclude
-            if (_context.ClassNamesToExclude.Contains(field.FullName))
-            {
-                referenceId = 0;
-                return false;
-            }
-
             var found = TryGetIdByValue(field, out referenceId);
             if (trackMaxReferenceId && found)
             {

--- a/source/MetadataProcessor.Core/Tables/nanoMethodDefinitionTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoMethodDefinitionTable.cs
@@ -54,13 +54,6 @@ namespace nanoFramework.Tools.MetadataProcessor
             MethodDefinition methodDefinition,
             out ushort referenceId)
         {
-            // compare against classes to exclude
-            if (_context.ClassNamesToExclude.Contains(methodDefinition.FullName))
-            {
-                referenceId = 0;
-                return false;
-            }
-
             return TryGetIdByValue(methodDefinition, out referenceId);
         }
 

--- a/source/MetadataProcessor.Core/Tables/nanoSignaturesTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoSignaturesTable.cs
@@ -40,33 +40,33 @@ namespace nanoFramework.Tools.MetadataProcessor
             }
         }
 
-        private static readonly IDictionary<string, nanoCLR_DataType> _primitiveTypes =
+        internal static readonly IDictionary<string, nanoCLR_DataType> PrimitiveTypes =
             new Dictionary<string, nanoCLR_DataType>(StringComparer.Ordinal);
 
         static nanoSignaturesTable()
         {
-            _primitiveTypes.Add(typeof(void).FullName, nanoCLR_DataType.DATATYPE_VOID);
+            PrimitiveTypes.Add(typeof(void).FullName, nanoCLR_DataType.DATATYPE_VOID);
 
-            _primitiveTypes.Add(typeof(sbyte).FullName, nanoCLR_DataType.DATATYPE_I1);
-            _primitiveTypes.Add(typeof(short).FullName, nanoCLR_DataType.DATATYPE_I2);
-            _primitiveTypes.Add(typeof(int).FullName, nanoCLR_DataType.DATATYPE_I4);
-            _primitiveTypes.Add(typeof(long).FullName, nanoCLR_DataType.DATATYPE_I8);
+            PrimitiveTypes.Add(typeof(sbyte).FullName, nanoCLR_DataType.DATATYPE_I1);
+            PrimitiveTypes.Add(typeof(short).FullName, nanoCLR_DataType.DATATYPE_I2);
+            PrimitiveTypes.Add(typeof(int).FullName, nanoCLR_DataType.DATATYPE_I4);
+            PrimitiveTypes.Add(typeof(long).FullName, nanoCLR_DataType.DATATYPE_I8);
 
-            _primitiveTypes.Add(typeof(byte).FullName, nanoCLR_DataType.DATATYPE_U1);
-            _primitiveTypes.Add(typeof(ushort).FullName, nanoCLR_DataType.DATATYPE_U2);
-            _primitiveTypes.Add(typeof(uint).FullName, nanoCLR_DataType.DATATYPE_U4);
-            _primitiveTypes.Add(typeof(ulong).FullName, nanoCLR_DataType.DATATYPE_U8);
+            PrimitiveTypes.Add(typeof(byte).FullName, nanoCLR_DataType.DATATYPE_U1);
+            PrimitiveTypes.Add(typeof(ushort).FullName, nanoCLR_DataType.DATATYPE_U2);
+            PrimitiveTypes.Add(typeof(uint).FullName, nanoCLR_DataType.DATATYPE_U4);
+            PrimitiveTypes.Add(typeof(ulong).FullName, nanoCLR_DataType.DATATYPE_U8);
 
-            _primitiveTypes.Add(typeof(float).FullName, nanoCLR_DataType.DATATYPE_R4);
-            _primitiveTypes.Add(typeof(double).FullName, nanoCLR_DataType.DATATYPE_R8);
+            PrimitiveTypes.Add(typeof(float).FullName, nanoCLR_DataType.DATATYPE_R4);
+            PrimitiveTypes.Add(typeof(double).FullName, nanoCLR_DataType.DATATYPE_R8);
 
-            _primitiveTypes.Add(typeof(char).FullName, nanoCLR_DataType.DATATYPE_CHAR);
-            _primitiveTypes.Add(typeof(string).FullName, nanoCLR_DataType.DATATYPE_STRING);
-            _primitiveTypes.Add(typeof(bool).FullName, nanoCLR_DataType.DATATYPE_BOOLEAN);
+            PrimitiveTypes.Add(typeof(char).FullName, nanoCLR_DataType.DATATYPE_CHAR);
+            PrimitiveTypes.Add(typeof(string).FullName, nanoCLR_DataType.DATATYPE_STRING);
+            PrimitiveTypes.Add(typeof(bool).FullName, nanoCLR_DataType.DATATYPE_BOOLEAN);
 
-            _primitiveTypes.Add(typeof(object).FullName, nanoCLR_DataType.DATATYPE_OBJECT);
-            _primitiveTypes.Add(typeof(IntPtr).FullName, nanoCLR_DataType.DATATYPE_I4);
-            _primitiveTypes.Add(typeof(UIntPtr).FullName, nanoCLR_DataType.DATATYPE_U4);
+            PrimitiveTypes.Add(typeof(object).FullName, nanoCLR_DataType.DATATYPE_OBJECT);
+            PrimitiveTypes.Add(typeof(IntPtr).FullName, nanoCLR_DataType.DATATYPE_I4);
+            PrimitiveTypes.Add(typeof(UIntPtr).FullName, nanoCLR_DataType.DATATYPE_U4);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             bool expandEnumType)
         {
             nanoCLR_DataType dataType;
-            if (_primitiveTypes.TryGetValue(typeDefinition.FullName, out dataType))
+            if (PrimitiveTypes.TryGetValue(typeDefinition.FullName, out dataType))
             {
                 writer.WriteByte((byte)dataType);
                 return;
@@ -309,7 +309,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             }
         }
 
-        private byte[] GetSignature(
+        internal byte[] GetSignature(
             IMethodSignature methodReference)
         {
             using (var buffer = new MemoryStream())
@@ -441,7 +441,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             CustomAttributeArgument argument)
         {
             nanoCLR_DataType dataType;
-            if (_primitiveTypes.TryGetValue(argument.Type.FullName, out dataType))
+            if (PrimitiveTypes.TryGetValue(argument.Type.FullName, out dataType))
             {
                 switch (dataType)
                 {

--- a/source/MetadataProcessor.Core/Tables/nanoTypeDefinitionTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoTypeDefinitionTable.cs
@@ -42,6 +42,8 @@ namespace nanoFramework.Tools.MetadataProcessor
         private IDictionary<uint, List<Tuple<uint, uint>>> _byteCodeOffsets =
             new Dictionary<uint, List<Tuple<uint, uint>>>();
 
+        public List<TypeDefinition> TypeDefinitions { get; }
+
         /// <summary>
         /// Creates new instance of <see cref="nanoTypeDefinitionTable"/> object.
         /// </summary>
@@ -54,6 +56,8 @@ namespace nanoFramework.Tools.MetadataProcessor
             nanoTablesContext context)
             : base(items, new TypeDefinitionEqualityComparer(), context)
         {
+            TypeDefinitions = items
+                .Select(t => t).ToList();
         }
 
         /// <summary>
@@ -139,7 +143,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                 writer.WriteBytes(stream.ToArray());
             }
 
-            writer.WriteUInt16(GetFlags(item)); // flags
+            writer.WriteUInt16((ushort)GetFlags(item)); // flags
         }
 
         private void WriteClassFields(
@@ -259,120 +263,93 @@ namespace nanoFramework.Tools.MetadataProcessor
             return 0xFFFF;
         }
 
-        private ushort GetFlags(
+        internal static nanoTypeDefinitionFlags GetFlags(
             TypeDefinition definition)
         {
-            const ushort TD_Scope_Public = 0x0001; // Class is public scope.
-            const ushort TD_Scope_NestedPublic = 0x0002; // Class is nested with public visibility.
-            const ushort TD_Scope_NestedPrivate = 0x0003; // Class is nested with private visibility.
-            const ushort TD_Scope_NestedFamily = 0x0004; // Class is nested with family visibility.
-            const ushort TD_Scope_NestedAssembly = 0x0005; // Class is nested with assembly visibility.
-            const ushort TD_Scope_NestedFamANDAssem = 0x0006; // Class is nested with family and assembly visibility.
-            const ushort TD_Scope_NestedFamORAssem = 0x0007; // Class is nested with family or assembly visibility.
-
-            const ushort TD_Serializable = 0x0008;
-
-            const ushort TD_Semantics_ValueType = 0x0010;
-            const ushort TD_Semantics_Interface = 0x0020;
-            const ushort TD_Semantics_Enum = 0x0030;
-
-            const ushort TD_Abstract = 0x0040;
-            const ushort TD_Sealed = 0x0080;
-
-            const ushort TD_SpecialName = 0x0100;
-            const ushort TD_Delegate = 0x0200;
-            const ushort TD_MulticastDelegate = 0x0400;
-            const ushort TD_Patched = 0x0800;
-
-            const ushort TD_BeforeFieldInit = 0x1000;
-            const ushort TD_HasSecurity = 0x2000;
-            const ushort TD_HasFinalizer = 0x4000;
-            const ushort TD_HasAttributes = 0x8000;
-
-            var flags = 0x0000;
+            var flags = nanoTypeDefinitionFlags.TD_Scope_None;
 
             if (definition.IsPublic)
             {
-                flags = TD_Scope_Public;
+                flags = nanoTypeDefinitionFlags.TD_Scope_Public;
             }
             else if (definition.IsNestedPublic)
             {
-                flags = TD_Scope_NestedPublic;
+                flags = nanoTypeDefinitionFlags.TD_Scope_NestedPublic;
             }
             else if (definition.IsNestedPrivate)
             {
-                flags = TD_Scope_NestedPrivate;
+                flags = nanoTypeDefinitionFlags.TD_Scope_NestedPrivate;
             }
             else if (definition.IsNestedFamily)
             {
-                flags = TD_Scope_NestedFamily;
+                flags = nanoTypeDefinitionFlags.TD_Scope_NestedFamily;
             }
             else if (definition.IsNestedAssembly)
             {
-                flags = TD_Scope_NestedAssembly;
+                flags = nanoTypeDefinitionFlags.TD_Scope_NestedAssembly;
             }
             else if (definition.IsNestedFamilyAndAssembly)
             {
-                flags = TD_Scope_NestedFamANDAssem;
+                flags = nanoTypeDefinitionFlags.TD_Scope_NestedFamANDAssem;
             }
             else if (definition.IsNestedFamilyOrAssembly)
             {
-                flags = TD_Scope_NestedFamORAssem;
+                flags = nanoTypeDefinitionFlags.TD_Scope_NestedFamORAssem;
             }
 
             if (definition.IsSerializable)
             {
-                flags |= TD_Serializable;
+                flags |= nanoTypeDefinitionFlags.TD_Serializable;
             }
 
             if (definition.IsEnum)
             {
-                flags |= TD_Semantics_Enum;
-                flags |= TD_Serializable;
+                flags |= nanoTypeDefinitionFlags.TD_Semantics_Enum;
+                flags |= nanoTypeDefinitionFlags.TD_Serializable;
             }
             else if (definition.IsValueType)
             {
-                flags |= TD_Semantics_ValueType;
+                flags |= nanoTypeDefinitionFlags.TD_Semantics_ValueType;
             }
             else if (definition.IsInterface)
             {
-                flags |= TD_Semantics_Interface;
+                flags |= nanoTypeDefinitionFlags.TD_Semantics_Interface;
             }
 
             if (definition.IsAbstract)
             {
-                flags |= TD_Abstract;
+                flags |= nanoTypeDefinitionFlags.TD_Abstract;
             }
             if (definition.IsSealed)
             {
-                flags |= TD_Sealed;
+                flags |= nanoTypeDefinitionFlags.TD_Sealed;
             }
 
             if (definition.IsSpecialName)
             {
-                flags |= TD_SpecialName;
+                flags |= nanoTypeDefinitionFlags.TD_SpecialName;
             }
 
             if (definition.IsBeforeFieldInit)
             {
-                flags |= TD_BeforeFieldInit;
+                flags |= nanoTypeDefinitionFlags.TD_BeforeFieldInit;
             }
             if (definition.HasSecurity)
             {
-                flags |= TD_HasSecurity;
+                flags |= nanoTypeDefinitionFlags.TD_HasSecurity;
             }
             if (definition.HasCustomAttributes)
             {
-                flags |= TD_HasAttributes;
+                flags |= nanoTypeDefinitionFlags.TD_HasAttributes;
             }
 
             var baseType = definition.BaseType;
             if (baseType != null && baseType.FullName == "System.MulticastDelegate")
             {
-                flags |= TD_MulticastDelegate;
+                flags |= nanoTypeDefinitionFlags.TD_MulticastDelegate;
             }
 
-            return (ushort)flags;
+            return flags;
         }
     }
 }

--- a/source/MetadataProcessor.Core/Utility/nanoTypeDefinitionFlags.cs
+++ b/source/MetadataProcessor.Core/Utility/nanoTypeDefinitionFlags.cs
@@ -1,0 +1,71 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System;
+
+namespace nanoFramework.Tools.MetadataProcessor
+{
+    /// <summary>
+    /// This list contains the type definition flags
+    /// </summary>
+    [Flags]
+    internal enum nanoTypeDefinitionFlags : ushort
+    {
+        // these where defined @ struct CLR_RECORD_TYPEDEF
+        TD_Scope_None = 0x0000,
+
+        // Class is public scope.
+        TD_Scope_Public = 0x0001,
+        // Class is nested with public visibility.
+        TD_Scope_NestedPublic = 0x0002,
+        // Class is nested with private visibility.
+        TD_Scope_NestedPrivate = 0x0003,
+        // Class is nested with family visibility.
+        TD_Scope_NestedFamily = 0x0004,
+        // Class is nested with assembly visibility.
+        TD_Scope_NestedAssembly = 0x0005,
+        // Class is nested with family and assembly visibility.
+        TD_Scope_NestedFamANDAssem = 0x0006,
+        // Class is nested with family or assembly visibility.
+        TD_Scope_NestedFamORAssem = 0x0007,
+
+        /// <summary>
+        /// Mask for scope flags
+        /// </summary>
+        TD_Scope = 
+            (TD_Scope_Public | 
+            TD_Scope_NestedPublic | 
+            TD_Scope_NestedPrivate |
+            TD_Scope_NestedFamily |
+            TD_Scope_NestedAssembly |
+            TD_Scope_NestedFamANDAssem |
+            TD_Scope_NestedFamORAssem ),
+
+        TD_Serializable = 0x0008,
+
+        TD_Semantics_ValueType = 0x0010,
+        TD_Semantics_Interface = 0x0020,
+        TD_Semantics_Enum = 0x0030,
+
+        /// <summary>
+        /// Mask for semantics flags
+        /// </summary>
+        TD_Semantics = (TD_Semantics_ValueType | TD_Semantics_Interface | TD_Semantics_Enum),
+
+        TD_Abstract = 0x0040,
+        TD_Sealed = 0x0080,
+
+        TD_SpecialName = 0x0100,
+        TD_Delegate = 0x0200,
+        TD_MulticastDelegate = 0x0400,
+
+        TD_Patched = 0x0800,
+
+        TD_BeforeFieldInit = 0x1000,
+        TD_HasSecurity = 0x2000,
+        TD_HasFinalizer = 0x4000,
+        TD_HasAttributes = 0x8000,
+    }
+}

--- a/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
+++ b/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
@@ -22,6 +22,8 @@ namespace nanoFramework.Tools.MetadataProcessor
         private readonly bool _minimize;
         private readonly bool _verbose;
 
+        public nanoTablesContext TablesContext => _tablesContext;
+
         /// <summary>
         /// Creates new instance of <see cref="nanoAssemblyBuilder"/> object.
         /// </summary>

--- a/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
+++ b/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
@@ -1,0 +1,263 @@
+﻿//
+// Copyright (c) 2019 The nanoFramework project contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using Mono.Cecil;
+using nanoFramework.Tools.MetadataProcessor.Core.Extensions;
+using Stubble.Core.Builders;
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace nanoFramework.Tools.MetadataProcessor.Core
+{
+    /// <summary>
+    /// Generator of skeleton files from a .NET nanoFramework assembly.
+    /// </summary>
+    public sealed class nanoSkeletonGenerator
+    {
+        private readonly nanoTablesContext _tablesContext;
+        private readonly string _path;
+        private readonly string _name;
+        private readonly string _project;
+        private readonly bool _interopCode;
+
+        private string _assemblyName;
+
+        public nanoSkeletonGenerator(
+            nanoTablesContext tablesContext,
+            string path,
+            string name,
+            string project,
+            bool interopCode)
+        {
+            _tablesContext = tablesContext;
+            _path = path;
+            _name = name;
+            _project = project;
+            _interopCode = interopCode;
+        }
+
+        public void GenerateSkeleton()
+        {
+            // replaces "." with "_" so the assembly name can be part of C++ identifier name
+            _assemblyName = _name.Replace('.', '_');
+
+            // create <assembly>.h with the structs declarations
+            GenerateAssemblyHeader();
+
+            // generate <assembly>.cpp with the lookup definition
+            GenerateAssemblyLookup();
+
+            // generate <assembly>_<type>.cpp files with the type definition and stubs.
+            GenerateStubs();
+        }
+
+        private void GenerateStubs()
+        {
+            foreach (var c in _tablesContext.TypeDefinitionTable.TypeDefinitions)
+            {
+                if (c.IncludeInStub() && !IsClassToExclude(c))
+                {
+                    var className = NativeMethodsCrc.GetClassName(c);
+
+                    var classStubs = new AssemblyClassStubs()
+                    {
+                        HeaderFileName = _project
+                    };
+
+                    foreach (var m in nanoTablesContext.GetOrderedMethods(c.Methods))
+                    {
+                        var rva = _tablesContext.ByteCodeTable.GetMethodRva(m);
+
+                        // check method inclusion
+                        if (rva == 0xFFFF &&
+                            !m.IsAbstract)
+                        {
+                            classStubs.Functions.Add(new Method()
+                            {
+                                Declaration = $"Library_{_project}_{className}::{NativeMethodsCrc.GetMethodName(m)}"
+                            });
+                        }
+                    }
+
+                    // anything to add to the header?
+                    if (classStubs.Functions.Count > 0)
+                    {
+                        var stubble = new StubbleBuilder().Build();
+
+                        using (var headerFile = File.CreateText(Path.Combine(_path, $"{_project}_{className}.cpp")))
+                        {
+                            var output = stubble.Render(SkeletonTemplates.ClassStubTemplate, classStubs);
+                            headerFile.Write(output);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void GenerateAssemblyLookup()
+        {
+            // grab native version from assembly attribute
+            var nativeVersionAttribute = _tablesContext.AssemblyDefinition.CustomAttributes.FirstOrDefault(a => a.AttributeType.Name == "AssemblyNativeVersionAttribute");
+            Version nativeVersion = new Version((string)nativeVersionAttribute.ConstructorArguments[0].Value);
+
+            var assemblyLookup = new AssemblyLookupTable()
+            {
+                Name = _name,
+                AssemblyName = _assemblyName,
+                HeaderFileName = _project,
+                NativeVersion = nativeVersion,
+                NativeCRC32 = "0x" + _tablesContext.NativeMethodsCrc.Current.ToString("X")
+            };
+
+
+            foreach (var c in _tablesContext.TypeDefinitionTable.TypeDefinitions)
+            {
+                if (c.IncludeInStub() && !IsClassToExclude(c))
+                {
+                    var className = NativeMethodsCrc.GetClassName(c);
+
+                    foreach (var m in nanoTablesContext.GetOrderedMethods(c.Methods))
+                    {
+                        var rva = _tablesContext.ByteCodeTable.GetMethodRva(m);
+
+                        // check method inclusion
+                        if ((rva == 0xFFFF &&
+                             !m.IsAbstract))
+                        {
+                            assemblyLookup.LookupTable.Add(new Method()
+                            {
+                                Declaration = $"Library_{_project}_{className}::{NativeMethodsCrc.GetMethodName(m)}"
+                            });
+                        }
+                        else
+                        {
+                            assemblyLookup.LookupTable.Add(new Method()
+                            {
+                                Declaration = "NULL"
+                            });
+                        }
+                    }
+                }
+            }
+
+            var stubble = new StubbleBuilder().Build();
+
+            using (var headerFile = File.CreateText(Path.Combine(_path, $"{_project}.cpp")))
+            {
+                var output = stubble.Render(SkeletonTemplates.AssemblyLookupTemplate, assemblyLookup);
+                headerFile.Write(output);
+            }
+        }
+
+        private void GenerateAssemblyHeader()
+        {
+            int staticFieldCount = 0;
+
+            var assemblyData = new AssemblyDeclaration()
+            {
+                Name = _name, 
+                ShortName = _project, 
+                ShortNameUpper = _project.ToUpperInvariant()
+            };
+
+            foreach (var c in _tablesContext.TypeDefinitionTable.TypeDefinitions)
+            {
+                if (c.IncludeInStub() && !IsClassToExclude(c))
+                {
+                    var classData = new Class()
+                    {
+                        AssemblyName = _project,
+                        Name = NativeMethodsCrc.GetClassName(c)
+                    };
+
+                    // static fields
+                    int fieldCount = 0;
+                    foreach (var f in c.Fields.Where(f => f.IsStatic))
+                    {
+                        classData.StaticFields.Add(new StaticField()
+                        {
+                            Name = f.Name,
+                            ReferenceIndex = staticFieldCount + fieldCount++
+                        });
+                    }
+
+                    // instance fields
+                    fieldCount = 0;
+                    foreach (var f in c.Fields.Where(f => !f.IsStatic))
+                    {
+                        // sanity check for field name
+                        // like auto-vars and such
+                        if (f.Name.IndexOfAny(new char[] { '<', '>' }) > 0)
+                        {
+                            classData.InstanceFields.Add(new InstanceField()
+                            {
+                                FieldWarning = $"*** Something wrong with field '{f.Name}'. Possibly its backing field is missing (mandatory for nanoFramework).\n"
+                            });
+                        }
+                        else
+                        {
+                            ushort fieldRefId;
+                            if (_tablesContext.FieldsTable.TryGetFieldReferenceId(f, false, out fieldRefId))
+                            {
+                                classData.InstanceFields.Add(new InstanceField()
+                                {
+                                    Name = f.Name,
+                                    ReferenceIndex = fieldRefId + 1
+                                });
+                            }
+                            fieldCount++;
+                        }
+                    }
+
+                    // methods
+                    if(c.HasMethods)
+                    {
+                        foreach (var m in nanoTablesContext.GetOrderedMethods(c.Methods))
+                        {
+                            var rva = _tablesContext.ByteCodeTable.GetMethodRva(m);
+
+                            if( rva == 0xFFFF &&
+                                !m.IsAbstract)
+                            {
+                                classData.Methods.Add(new Method()
+                                {
+                                    Declaration = NativeMethodsCrc.GetMethodName(m)
+                                });
+                            }
+                        }
+
+                    }
+
+                    // anything to add to the header?
+                    if( classData.StaticFields.Count > 0 ||
+                        classData.InstanceFields.Count > 0 ||
+                        classData.Methods.Count > 0)
+                    {
+                        assemblyData.Classes.Add(classData);
+                    }
+                }
+
+                staticFieldCount += c.Fields.Count(f => f.IsStatic);
+            }
+
+            var stubble = new StubbleBuilder().Build();
+
+            Directory.CreateDirectory(_path);
+
+            using (var headerFile = File.CreateText(Path.Combine(_path, $"{_project}.h")))
+            {
+                var output = stubble.Render(SkeletonTemplates.AssemblyHeaderTemplate, assemblyData);
+                headerFile.Write(output);
+            }
+        }
+
+        private bool IsClassToExclude(TypeDefinition td)
+        {
+            return _tablesContext.ClassNamesToExclude.Contains(td.FullName);
+        }
+    }
+}

--- a/source/MetadataProcessor.Core/packages.config
+++ b/source/MetadataProcessor.Core/packages.config
@@ -2,4 +2,8 @@
 <packages>
   <package id="Mono.Cecil" version="0.11.1" targetFramework="net461" />
   <package id="Nerdbank.GitVersioning" version="3.0.28" targetFramework="net461" developmentDependency="true" />
+  <package id="Stubble.Core" version="1.6.3" targetFramework="net461" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net461" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
- Fix generation of method name and class names to follow .NETMF rules.
- Fix native methods CRC32 calculation.
- Fix implementation of class name to exclude.
- Major rework on several helper classes to make the above work.
- Add templates for assembly header, lookup table and class stubs.

⚠️ Regular and core libs. Interop is not supported yet. ⚠️

Signed-off-by: José Simões <jose.simoes@eclo.solutions>