### PR TITLE
NuGet package now contains Core DLL instead of Console app

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,7 @@ jobs:
   - task: NuGetCommand@2
     inputs:
       command: 'custom' 
-      arguments: 'pack source\MetadataProcessor.Console\package.nuspec -Version $(NBGV_NuGetPackageVersion)'
+      arguments: 'pack source\MetadataProcessor.Core\package.nuspec -Version $(NBGV_NuGetPackageVersion)'
     condition: succeeded()
     displayName: Pack NuGet for MDP tool
 

--- a/source/MetadataProcessor.Core/package.nuspec
+++ b/source/MetadataProcessor.Core/package.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>nanoFramework.Tools.MetadataProcessor</id>
-    <title>nanoFramework.Tools.MetadataProcessor</title>
+    <id>nanoFramework.Tools.MetadataProcessor.Core</id>
+    <title>nanoFramework.Tools.MetadataProcessor.Core</title>
     <version>$version$</version>
     <authors>nanoFramework project contributors</authors>
     <owners>nanoFramework project contributors</owners>
@@ -19,12 +19,14 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <licenseUrl>https://github.com/nanoframework/metadata-processor/LICENSE</licenseUrl>
     <copyright>Copyright (c) 2019 The nanoFramework project contributors</copyright>
-    <dependencies></dependencies>
     <references></references>
     <tags>nanoFramework, nano Framework, NETNF, NETMF, Micro Framework, .net</tags>
+    <dependencies>
+      <dependency id="Mono.Cecil" version="0.11.1" />
+      <dependency id="Stubble.Core" version="1.6.3" />
+    </dependencies>
   </metadata>
   <files>
-    <file src="bin\Release\nanoFramework.Tools.MetaDataProcessor.exe" target="build" />
-    <file src="nanoFramework.Tools.MetaDataProcessor.targets" target="build" />
+    <file src="bin\Release\nanoFramework.Tools.MetadataProcessor.Core.dll" target="build" />
   </files>
 </package>

--- a/source/version.json
+++ b/source/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.0",
+  "version": "2.1",
   "assemblyVersion": {
     "precision": "build"
   },


### PR DESCRIPTION
- Console app is no longer packaged for distribution.
- Bump version to 2.1.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>