### PR TITLE
Fix compile to output native methods CRC for core libraries

### DIFF
--- a/source/MetadataProcessor.Console/Program.cs
+++ b/source/MetadataProcessor.Console/Program.cs
@@ -48,13 +48,15 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                 }
             }
 
-            public void Compile(string fileName)
+            public void Compile(
+                string fileName,
+                bool isCoreLibrary)
             {
                 try
                 {
                     if (Verbose) System.Console.WriteLine("Compiling assembly...");
 
-                    _assemblyBuilder = new nanoAssemblyBuilder(_assemblyDefinition, _classNamesToExclude, Minimize, Verbose);
+                    _assemblyBuilder = new nanoAssemblyBuilder(_assemblyDefinition, _classNamesToExclude, Minimize, Verbose, isCoreLibrary);
 
                     using (var stream = File.Open(fileName, FileMode.Create, FileAccess.ReadWrite))
                     using (var writer = new BinaryWriter(stream))
@@ -180,7 +182,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                 {
                     System.Console.WriteLine("");
                     System.Console.WriteLine("-parse <path-to-assembly-file>                        Analyses .NET assembly.");
-                    System.Console.WriteLine("-compile <path-to-PE-file>                            Compiles an assembly into nanoCLR format.");
+                    System.Console.WriteLine("-compile <path-to-PE-file>                            Compiles an assembly into nanoCLR format. Optionally flags if this it's a core library.");
                     System.Console.WriteLine("-loadHints <assembly-name> <path-to-assembly-file>    Loads one (or more) assembly file(s) as a dependency(ies).");
                     System.Console.WriteLine("-excludeClassByName <class-name>                      Removes the class from an assembly.");
                     System.Console.WriteLine("-generateskeleton                                     Generate skeleton files with stubs to add native code for an assembly.");
@@ -193,9 +195,18 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                 {
                     md.Parse(args[++i]);
                 }
-                else if (arg == "-compile" && i + 1 < args.Length)
+                else if (arg == "-compile" && i + 2 < args.Length)
                 {
-                    md.Compile(args[++i]);
+                    bool isCoreLibrary = false;
+
+                    if (!bool.TryParse(args[i + 2], out isCoreLibrary))
+                    {
+                        System.Console.Error.WriteLine("Bad parameter for compile. IsCoreLib options has to be 'true' or 'false'.");
+
+                        Environment.Exit(1);
+                    }
+
+                    md.Compile(args[i + 1], isCoreLibrary);
                 }
                 else if (arg == "-excludeclassbyname" && i + 1 < args.Length)
                 {

--- a/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
+++ b/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
@@ -21,6 +21,7 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         private readonly bool _minimize;
         private readonly bool _verbose;
+        private readonly bool _isCoreLibrary;
 
         public nanoTablesContext TablesContext => _tablesContext;
 
@@ -38,6 +39,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             List<string> classNamesToExclude,
             bool minimize,
             bool verbose,
+            bool isCoreLibrary = false,
             List<string> explicitTypesOrder = null,
             ICustomStringSorter stringSorter = null,
             bool applyAttributesCompression = false)
@@ -51,6 +53,7 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             _minimize = minimize;
             _verbose = verbose;
+            _isCoreLibrary = isCoreLibrary;
         }
 
         /// <summary>
@@ -60,7 +63,9 @@ namespace nanoFramework.Tools.MetadataProcessor
         public void Write(
             nanoBinaryWriter binaryWriter)
         {
-            var header = new nanoAssemblyDefinition(_tablesContext);
+            var header = new nanoAssemblyDefinition(
+                _tablesContext,
+                _isCoreLibrary);
             header.Write(binaryWriter, true);
 
             foreach (var table in GetTables(_tablesContext))

--- a/source/MetadataProcessor.Core/nanoAssemblyDefinition.cs
+++ b/source/MetadataProcessor.Core/nanoAssemblyDefinition.cs
@@ -34,6 +34,11 @@ namespace nanoFramework.Tools.MetadataProcessor
         private readonly nanoTablesContext _context;
 
         /// <summary>
+        /// Flag for core libraries.
+        /// </summary>
+        private readonly bool _isCoreLibrary = false;
+
+        /// <summary>
         /// Offset for current table address writing.
         /// </summary>
         private long _tablesOffset;
@@ -50,9 +55,11 @@ namespace nanoFramework.Tools.MetadataProcessor
         /// Assembly tables context - contains all tables used for building target assembly.
         /// </param>
         public nanoAssemblyDefinition(
-            nanoTablesContext context)
+            nanoTablesContext context,
+            bool isCoreLibrary)
         {
             _context = context;
+            _isCoreLibrary = isCoreLibrary;
         }
 
         /// <summary>
@@ -82,8 +89,8 @@ namespace nanoFramework.Tools.MetadataProcessor
             // keeping this here for now, just for compatibility
             writer.WriteUInt32(0);
 
-            // native methods CRC32
-            writer.WriteUInt32(writer.IsBigEndian ? _context.NativeMethodsCrc.Current : 0);
+            // native methods CRC32, only for core libs
+            writer.WriteUInt32(_isCoreLibrary ? _context.NativeMethodsCrc.Current : 0);
 
             // Native methods offset
             writer.WriteUInt32(0xFFFFFFFF);


### PR DESCRIPTION
- Wasn't writing this field thus preventing deployment and assembly check on target boot.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>