### PR TITLE
Several fixes in signature generation

### DIFF
--- a/source/MetadataProcessor.Core/Tables/nanoSignaturesTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoSignaturesTable.cs
@@ -46,7 +46,7 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         static nanoSignaturesTable()
         {
-            PrimitiveTypes.Add(typeof(void).FullName, nanoCLR_DataType.DATATYPE_VALUETYPE);
+            PrimitiveTypes.Add(typeof(void).FullName, nanoCLR_DataType.DATATYPE_VOID);
 
             PrimitiveTypes.Add(typeof(sbyte).FullName, nanoCLR_DataType.DATATYPE_I1);
             PrimitiveTypes.Add(typeof(short).FullName, nanoCLR_DataType.DATATYPE_I2);
@@ -68,13 +68,6 @@ namespace nanoFramework.Tools.MetadataProcessor
             PrimitiveTypes.Add(typeof(object).FullName, nanoCLR_DataType.DATATYPE_OBJECT);
             PrimitiveTypes.Add(typeof(IntPtr).FullName, nanoCLR_DataType.DATATYPE_VALUETYPE);
             //PrimitiveTypes.Add(typeof(UIntPtr).FullName, nanoCLR_DataType.DATATYPE_U4);
-
-            PrimitiveTypes.Add("System.DateTime", nanoCLR_DataType.DATATYPE_DATETIME);
-            PrimitiveTypes.Add("System.TimeSpan", nanoCLR_DataType.DATATYPE_TIMESPAN);
-
-            PrimitiveTypes.Add("System.RuntimeTypeHandle", nanoCLR_DataType.DATATYPE_REFLECTION);
-            PrimitiveTypes.Add("System.RuntimeFieldHandle", nanoCLR_DataType.DATATYPE_REFLECTION);
-            PrimitiveTypes.Add("System.RuntimeMethodHandle", nanoCLR_DataType.DATATYPE_REFLECTION);
 
             PrimitiveTypes.Add("System.WeakReference", nanoCLR_DataType.DATATYPE_WEAKCLASS);
         }

--- a/source/MetadataProcessor.Core/Utility/NativeMethodsCrc.cs
+++ b/source/MetadataProcessor.Core/Utility/NativeMethodsCrc.cs
@@ -126,7 +126,26 @@ namespace nanoFramework.Tools.MetadataProcessor
             nanoCLR_DataType myType;
             if(nanoSignaturesTable.PrimitiveTypes.TryGetValue(parameterType.FullName, out myType))
             {
-                return myType.ToString();
+                if (myType == nanoCLR_DataType.DATATYPE_LAST_PRIMITIVE)
+                {
+                    return "DATATYPE_STRING";
+                }
+                else if (myType == nanoCLR_DataType.DATATYPE_LAST_NONPOINTER)
+                {
+                    return "DATATYPE_TIMESPAN";
+                }
+                else if (myType == nanoCLR_DataType.DATATYPE_LAST_PRIMITIVE_TO_MARSHAL)
+                {
+                    return "DATATYPE_TIMESPAN";
+                }
+                else if (myType == nanoCLR_DataType.DATATYPE_LAST_PRIMITIVE_TO_PRESERVE)
+                {
+                    return "DATATYPE_R8";
+                }
+                else
+                {
+                    return myType.ToString();
+                }
             }
             else
             {

--- a/source/MetadataProcessor.Core/Utility/nanoCLR_DataType.cs
+++ b/source/MetadataProcessor.Core/Utility/nanoCLR_DataType.cs
@@ -38,7 +38,7 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         // All the above types can be marshaled by assignment.
 #if NANOCLR_NO_ASSEMBLY_STRINGS
-        DATATYPE_LAST_PRIMITIVE_TO_MARSHAL  = DATATYPE_STRING,
+        DATATYPE_LAST_PRIMITIVE_TO_MARSHAL = DATATYPE_STRING,
 #else
         DATATYPE_LAST_PRIMITIVE_TO_MARSHAL = DATATYPE_TIMESPAN,
 #endif

--- a/source/MetadataProcessor.Core/Utility/nanoSerializationType.cs
+++ b/source/MetadataProcessor.Core/Utility/nanoSerializationType.cs
@@ -29,7 +29,7 @@ namespace nanoFramework.Tools.MetadataProcessor
         ELEMENT_TYPE_STRING = 0xe,
 
         // every type above PTR will be simple type
-        ELEMENT_TYPE_PTR = 0xf,      // PTR <type>
+        ELEMENT_TYPE_PTR = 0x0F,      // PTR <type>
         ELEMENT_TYPE_BYREF = 0x10,     // BYREF <type>
 
         // Please use ELEMENT_TYPE_VALUETYPE. ELEMENT_TYPE_VALUECLASS is deprecated.

--- a/source/MetadataProcessor.Core/nanoDumperGenerator.cs
+++ b/source/MetadataProcessor.Core/nanoDumperGenerator.cs
@@ -292,10 +292,15 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     case nanoCLR_DataType.DATATYPE_U8:
                     case nanoCLR_DataType.DATATYPE_R4:
                     case nanoCLR_DataType.DATATYPE_R8:
-                    case nanoCLR_DataType.DATATYPE_STRING:
                     case nanoCLR_DataType.DATATYPE_BYREF:
                     case nanoCLR_DataType.DATATYPE_OBJECT:
                         return dataType.ToString().Replace("DATATYPE_", "");
+
+                    case nanoCLR_DataType.DATATYPE_LAST_PRIMITIVE:
+                        return "STRING";
+
+                    case nanoCLR_DataType.DATATYPE_REFLECTION:
+                        return type.FullName.Replace(".", "");
                 }
             }
 

--- a/source/native/Tools.Parser/AssemblyParserDump.cpp
+++ b/source/native/Tools.Parser/AssemblyParserDump.cpp
@@ -493,36 +493,60 @@ void MetaData::Parser::Dump_EnumTypeDefs( bool fNoByteCode )
                     const CLR_UINT8* IP    = il.Code;
                     const CLR_UINT8* IPend = IP + il.GetCodeSize();
 
+					CLR_UINT16 ilCount = 0;
+
+					// 1st pass: count the number of instructions
                     while(IP < IPend)
                     {
                         CLR_OPCODE op = CLR_ReadNextOpcode( IP );
 
-                        fwprintf( m_output, L"           %-12S", c_CLR_RT_OpcodeLookup[op].m_name );
-
                         if(IsOpParamToken( c_CLR_RT_OpcodeLookup[op].m_opParam ))
                         {
                             CLR_UINT32 arg; NANOCLR_READ_UNALIGNED_UINT32( arg, IP );
-
-                            fwprintf( m_output, L"[%08x]", arg );
                         }
                         else
                         {
                             IP = CLR_SkipBodyOfOpcode( IP, op );
                         }
 
-                        fwprintf( m_output, L"\n" );
+						ilCount++;
                     }
+
+					fwprintf(m_output, L"        IL count: %d\n", ilCount);
+
+					IP = il.Code;
+					IPend = IP + il.GetCodeSize();
+
+					// 2nd pass: output the instructions
+					while (IP < IPend)
+					{
+						CLR_OPCODE op = CLR_ReadNextOpcode(IP);
+
+						fwprintf(m_output, L"           %-12S", c_CLR_RT_OpcodeLookup[op].m_name);
+
+						if (IsOpParamToken(c_CLR_RT_OpcodeLookup[op].m_opParam))
+						{
+							CLR_UINT32 arg; NANOCLR_READ_UNALIGNED_UINT32(arg, IP);
+
+							fwprintf(m_output, L"[%08x]", arg);
+						}
+						else
+						{
+							IP = CLR_SkipBodyOfOpcode(IP, op);
+						}
+
+						fwprintf(m_output, L"\n");
+					}
+
                 }
             }
-
-            fwprintf( m_output, L"\n" );
         }
 
         for(mdInterfaceImplListIter it3 = td.m_interfaces.begin(); it3 != td.m_interfaces.end(); it3++)
         {
             InterfaceImpl& ii = m_mapDef_Interface[*it3];
 
-            fwprintf( m_output, L"    InterfaceImplProps [%08x]: Itf: %08x\n", ii.m_td, ii.m_itf );
+            fwprintf( m_output, L"    InterfaceImplProps [%08x]: Itf: %08x\n", *it3, ii.m_itf );
         }
 
         fwprintf( m_output, L"\n" );


### PR DESCRIPTION
- Remove wrong entries in Primitives dictionary.
- Fix output of method parameters types.
- Fix output of dump CLR types.
- Add extra output to native MDP dumper (to output IL count for each method).

Signed-off-by: José Simões <jose.simoes@eclo.solutions>