### PR TITLE
Fix type references processing

### DIFF
--- a/source/MetadataProcessor.Console/Program.cs
+++ b/source/MetadataProcessor.Console/Program.cs
@@ -69,6 +69,18 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                         _assemblyBuilder.Write(GetBinaryWriter(writer));
                     }
 
+                    if (Verbose) System.Console.WriteLine("Minimizing assembly...");
+
+                    _assemblyBuilder.Minimize();
+
+                    if (Verbose) System.Console.WriteLine("Recompiling assembly...");
+
+                    using (var stream = File.Open(fileName, FileMode.Create, FileAccess.ReadWrite))
+                    using (var writer = new BinaryWriter(stream))
+                    {
+                        _assemblyBuilder.Write(GetBinaryWriter(writer));
+                    }
+
                     using (var writer = XmlWriter.Create(Path.ChangeExtension(fileName, "pdbx")))
                     {
                         _assemblyBuilder.Write(writer);
@@ -86,42 +98,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                 {
                     System.Console.Error.WriteLine(
                         "Unable to compile output assembly file '{0}' - check parse command results.", fileName);
-                    throw;
-                }
-            }
-
-            public void Minimize(
-                string fileName)
-            {
-                try
-                {
-                    if (Verbose) System.Console.WriteLine("Minimizing assembly...");
-
-                    _assemblyBuilder.Minimize();
-
-                    using (var stream = File.Open(fileName, FileMode.Create, FileAccess.ReadWrite))
-                    using (var writer = new BinaryWriter(stream))
-                    {
-                        _assemblyBuilder.Write(GetBinaryWriter(writer));
-                    }
-
-                    using (var writer = XmlWriter.Create(Path.ChangeExtension(fileName, "pdbx")))
-                    {
-                        _assemblyBuilder.Write(writer);
-                    }
-
-                    if (DumpMetadata)
-                    {
-                        nanoDumperGenerator dumper = new nanoDumperGenerator(
-                            _assemblyBuilder.TablesContext,
-                            Path.ChangeExtension(fileName, "dump.txt"));
-                        dumper.DumpAll();
-                    }
-                }
-                catch (Exception ex)
-                {
-                    System.Console.Error.WriteLine(
-                        "Unable to minimize assembly file '{0}'.", fileName);
                     throw;
                 }
             }
@@ -232,7 +208,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                     System.Console.WriteLine("-excludeClassByName <class-name>                      Removes the class from an assembly.");
                     System.Console.WriteLine("-generateskeleton                                     Generate skeleton files with stubs to add native code for an assembly.");
                     System.Console.WriteLine("-generateDependency                                   Generates an XML file with the relationship between assemblies.");
-                    System.Console.WriteLine("-minimize                                             Minimizes the assembly, removing unwanted elements.");
                     System.Console.WriteLine("-verbose                                              Outputs each command before executing it.");
                     System.Console.WriteLine("-verboseMinimize                                      Turns on verbose level for the minimization phase.");
                     System.Console.WriteLine("-dump_all                                             Generates a report of an assembly's metadata.");
@@ -262,10 +237,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                 else if (arg == "-excludeclassbyname" && i + 1 < args.Length)
                 {
                     md.AddClassToExclude(args[++i]);
-                }
-                else if (arg == "-minimize")
-                {
-                    md.Minimize(md.PeFileName);
                 }
                 else if (arg == "-verbose")
                 {

--- a/source/MetadataProcessor.Core/Tables/nanoTablesContext.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoTablesContext.cs
@@ -19,14 +19,6 @@ namespace nanoFramework.Tools.MetadataProcessor
                 // Assembly-level attributes
                 "System.Runtime.InteropServices.ComVisibleAttribute",
                 "System.Runtime.InteropServices.GuidAttribute",
-                "System.Reflection.AssemblyTitleAttribute",
-                "System.Reflection.AssemblyDescriptionAttribute",
-                "System.Reflection.AssemblyConfigurationAttribute",
-                "System.Reflection.AssemblyCompanyAttribute",
-                "System.Reflection.AssemblyProductAttribute",
-                "System.Reflection.AssemblyCopyrightAttribute",
-                "System.Reflection.AssemblyTrademarkAttribute",
-                "System.Reflection.AssemblyFileVersionAttribute",
 
                 // Compiler-specific attributes
                 //"System.ParamArrayAttribute",
@@ -108,17 +100,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             AssemblyReferenceTable = new nanoAssemblyReferenceTable(
                 mainModule.AssemblyReferences, this);
 
-            var typeReferences = mainModule.GetTypeReferences().ToList();
-            
-            // remove types in ignore list
-            foreach (var a in _ignoringAttributes)
-            {
-                var typeToExclude = typeReferences.FirstOrDefault(t => t.FullName == a);
-                if (typeToExclude != null)
-                {
-                    typeReferences.Remove(typeToExclude);
-                }
-            }
+            var typeReferences = mainModule.GetTypeReferences();
 
             TypeReferencesTable = new nanoTypeReferenceTable(
                 typeReferences, this);
@@ -139,16 +121,6 @@ namespace nanoFramework.Tools.MetadataProcessor
             // Internal types definitions
 
             var types = GetOrderedTypes(mainModule, explicitTypesOrder);
-
-            // remove types in ignore list
-            foreach (var a in _ignoringAttributes)
-            {
-                var typeToExclude = types.FirstOrDefault(t => t.FullName == a);
-                if(typeToExclude != null)
-                {
-                    types.Remove(typeToExclude);
-                }
-            }
 
             TypeDefinitionTable = new nanoTypeDefinitionTable(types, this);
             

--- a/source/MetadataProcessor.Core/Tables/nanoTypeReferenceTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoTypeReferenceTable.cs
@@ -92,7 +92,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             GetOrCreateStringId(item.Name);
         }
 
-        private ushort GetScope(
+        internal ushort GetScope(
             TypeReference typeReference)
         {
             if (typeReference.DeclaringType == null)

--- a/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
+++ b/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
@@ -156,6 +156,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             // need to reset several tables so they are recreated only with the used items
             _tablesContext.ResetStringsTable();
             _tablesContext.AssemblyReferenceTable.RemoveUnusedItems(set);
+            _tablesContext.TypeReferencesTable.RemoveUnusedItems(set);
             _tablesContext.FieldsTable.RemoveUnusedItems(set);
             _tablesContext.FieldReferencesTable.RemoveUnusedItems(set);
             _tablesContext.MethodDefinitionTable.RemoveUnusedItems(set);

--- a/source/MetadataProcessor.Core/nanoDumperGenerator.cs
+++ b/source/MetadataProcessor.Core/nanoDumperGenerator.cs
@@ -235,18 +235,16 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
             {
                 ushort refId;
 
-                var metadataScopeType = _tablesContext.AssemblyReferenceTable.Items.FirstOrDefault(a => a == t.Scope);
-
                 var typeRef = new TypeRef()
                 {
                     Name = t.Name,
-                    Scope = _tablesContext.AssemblyReferenceTable.GetReferenceId(metadataScopeType).ToString("x8")
+                    Scope = _tablesContext.TypeReferencesTable.GetScope(t).ToString("x8")
                 };
 
                 if (_tablesContext.TypeReferencesTable.TryGetTypeReferenceId(t, out refId))
                 {
                     typeRef.ReferenceId = "0x" + refId.ToString("x8");
-                    typeRef.Name = t.Name;
+                    typeRef.Name = t.FullName;
                 }
 
                 // TODO 


### PR DESCRIPTION
- Remove assembly attributes from ignore list (not required as they will be added as non used items).
- Remove minimize command. Now all assemblies are minimized by default.
- Add missing call to RemoveUnusedItems() in TypeReferencesTable.
- Improve dumping of type references entry: wasn't getting the correct scope.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>