### PR TITLE
Fix issue with bye code output

### DIFF
--- a/source/MetadataProcessor.Console/Program.cs
+++ b/source/MetadataProcessor.Console/Program.cs
@@ -63,11 +63,14 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
 
                     _assemblyBuilder = new nanoAssemblyBuilder(_assemblyDefinition, _classNamesToExclude, VerboseMinimize, isCoreLibrary);
 
-                    using (var stream = File.Open(fileName, FileMode.Create, FileAccess.ReadWrite))
+                    using (var stream = File.Open(Path.ChangeExtension(fileName, "tmp"), FileMode.Create, FileAccess.ReadWrite))
                     using (var writer = new BinaryWriter(stream))
                     {
                         _assemblyBuilder.Write(GetBinaryWriter(writer));
                     }
+
+                    // OK to delete tmp PE file
+                    File.Delete(Path.ChangeExtension(fileName, "tmp"));
 
                     if (Verbose) System.Console.WriteLine("Minimizing assembly...");
 

--- a/source/MetadataProcessor.Core/Tables/nanoAssemblyReferenceTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoAssemblyReferenceTable.cs
@@ -55,6 +55,11 @@ namespace nanoFramework.Tools.MetadataProcessor
             nanoBinaryWriter writer,
             AssemblyNameReference item)
         {
+            if (!_context.MinimizeComplete)
+            {
+                return;
+            }
+
             WriteStringReference(writer, item.Name);
             writer.WriteUInt16(0); // padding
 

--- a/source/MetadataProcessor.Core/Tables/nanoByteCodeTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoByteCodeTable.cs
@@ -24,13 +24,13 @@ namespace nanoFramework.Tools.MetadataProcessor
         private readonly IList<MethodDefinition> _methods = new List<MethodDefinition>();
 
         /// <summary>
-        /// Maps method full names to method RVAs (offsets in resutling table).
+        /// Maps method full names to method RVAs (offsets in resulting table).
         /// </summary>
         private readonly IDictionary<string, ushort> _rvasByMethodNames =
             new Dictionary<string, ushort>(StringComparer.Ordinal);
 
         /// <summary>
-        /// Temprorary string table for code generators used duing initial load.
+        /// Temporary string table for code generators used during initial load.
         /// </summary>
         private readonly nanoStringTable _fakeStringTable = new nanoStringTable();
 
@@ -57,12 +57,12 @@ namespace nanoFramework.Tools.MetadataProcessor
         }
 
         /// <summary>
-        /// Next method identifier. Used for reproducing strange original MetadataProcessor behavior.
+        /// Next method identifier. Used for reproducing strange original MetadataProcessor behaviour.
         /// </summary>
         public ushort NextMethodId { get { return (ushort)_methods.Count; } }
 
         /// <summary>
-        /// Temprorary string table for code generators used duing initial load.
+        /// Temporary string table for code generators used duing initial load.
         /// </summary>
         public nanoStringTable FakeStringTable { get { return _fakeStringTable; } }
 

--- a/source/MetadataProcessor.Core/Tables/nanoFieldDefinitionTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoFieldDefinitionTable.cs
@@ -66,6 +66,11 @@ namespace nanoFramework.Tools.MetadataProcessor
             nanoBinaryWriter writer,
             FieldDefinition item)
         {
+            if (!_context.MinimizeComplete)
+            {
+                return;
+            }
+
             WriteStringReference(writer, item.Name);
             writer.WriteUInt16(_context.SignaturesTable.GetOrCreateSignatureId(item));
 

--- a/source/MetadataProcessor.Core/Tables/nanoFieldReferenceTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoFieldReferenceTable.cs
@@ -68,6 +68,11 @@ namespace nanoFramework.Tools.MetadataProcessor
             nanoBinaryWriter writer,
             FieldReference item)
         {
+            if (!_context.MinimizeComplete)
+            {
+                return;
+            }
+
             ushort referenceId;
             _context.TypeReferencesTable.TryGetTypeReferenceId(item.DeclaringType, out referenceId);
 

--- a/source/MetadataProcessor.Core/Tables/nanoMethodDefinitionTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoMethodDefinitionTable.cs
@@ -1,6 +1,6 @@
+using Mono.Cecil;
 using System;
 using System.Collections.Generic;
-using Mono.Cecil;
 
 namespace nanoFramework.Tools.MetadataProcessor
 {
@@ -62,6 +62,11 @@ namespace nanoFramework.Tools.MetadataProcessor
             nanoBinaryWriter writer,
             MethodDefinition item)
         {
+            if (!_context.MinimizeComplete)
+            {
+                return;
+            }
+
             WriteStringReference(writer, item.Name);
             writer.WriteUInt16(_context.ByteCodeTable.GetMethodRva(item));
 

--- a/source/MetadataProcessor.Core/Tables/nanoMethodReferenceTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoMethodReferenceTable.cs
@@ -68,6 +68,11 @@ namespace nanoFramework.Tools.MetadataProcessor
             nanoBinaryWriter writer,
             MethodReference item)
         {
+            if (!_context.MinimizeComplete)
+            {
+                return;
+            }
+
             ushort referenceId;
             _context.TypeReferencesTable.TryGetTypeReferenceId(item.DeclaringType, out referenceId);
 

--- a/source/MetadataProcessor.Core/Tables/nanoTablesContext.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoTablesContext.cs
@@ -241,6 +241,7 @@ namespace nanoFramework.Tools.MetadataProcessor
         public nanoResourceFileTable ResourceFileTable { get; private set; }
 
         public static List<string> ClassNamesToExclude { get; private set; }
+        public bool MinimizeComplete { get; internal set; } = false;
 
         private IEnumerable<Tuple<CustomAttribute, ushort>> GetAttributes(
             IEnumerable<ICustomAttributeProvider> types,

--- a/source/MetadataProcessor.Core/Tables/nanoTypeDefinitionTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoTypeDefinitionTable.cs
@@ -110,34 +110,38 @@ namespace nanoFramework.Tools.MetadataProcessor
             {
                 WriteClassFields(fieldsList, writer.GetMemoryBasedClone(stream));
 
-                if (item.DeclaringType == null)
+                if (_context.MinimizeComplete)
                 {
-                    foreach (var method in item.Methods)
+
+                    if (item.DeclaringType == null)
                     {
-                        var offsets = CodeWriter
-                            .PreProcessMethod(method, _context.ByteCodeTable.FakeStringTable)
-                            .ToList();
+                        foreach (var method in item.Methods)
+                        {
+                            var offsets = CodeWriter
+                                .PreProcessMethod(method, _context.ByteCodeTable.FakeStringTable)
+                                .ToList();
 
-                        _byteCodeOffsets.Add(method.MetadataToken.ToUInt32(), offsets);
+                            _byteCodeOffsets.Add(method.MetadataToken.ToUInt32(), offsets);
+                        }
                     }
-                }
-                foreach (var nestedType in item.NestedTypes)
-                {
-                    foreach (var method in nestedType.Methods)
+                    foreach (var nestedType in item.NestedTypes)
                     {
-                        var offsets = CodeWriter
-                            .PreProcessMethod(method, _context.ByteCodeTable.FakeStringTable)
-                            .ToList();
+                        foreach (var method in nestedType.Methods)
+                        {
+                            var offsets = CodeWriter
+                                .PreProcessMethod(method, _context.ByteCodeTable.FakeStringTable)
+                                .ToList();
 
-                        _byteCodeOffsets.Add(method.MetadataToken.ToUInt32(), offsets);
+                            _byteCodeOffsets.Add(method.MetadataToken.ToUInt32(), offsets);
+                        }
                     }
+
+                    WriteMethodBodies(item.Methods, item.Interfaces, writer);
+
+                    _context.SignaturesTable.WriteDataType(item, writer, false, true, true);
+
+                    writer.WriteBytes(stream.ToArray());
                 }
-
-                WriteMethodBodies(item.Methods, item.Interfaces, writer);
-
-                _context.SignaturesTable.WriteDataType(item, writer, false, true, true);
-
-                writer.WriteBytes(stream.ToArray());
             }
 
             writer.WriteUInt16((ushort)GetFlags(item)); // flags

--- a/source/MetadataProcessor.Core/Utility/nanoPdbxFileWriter.cs
+++ b/source/MetadataProcessor.Core/Utility/nanoPdbxFileWriter.cs
@@ -7,6 +7,7 @@
 using Mono.Cecil;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
 using System.Xml;
@@ -75,12 +76,26 @@ namespace nanoFramework.Tools.MetadataProcessor
                     writer.WriteElementString("HasByteCode", "false");
                 }
                 writer.WriteStartElement("ILMap");
+
+                // sanity check vars
+                uint prevItem1 = 0;
+                uint prevItem2 = 0;
+
                 foreach (var offset in _context.TypeDefinitionTable.GetByteCodeOffsets(tuple.Item1))
                 {
+                    if (prevItem1 > 0)
+                    {
+                        // 1st pass, load prevs with current values
+                        Debug.Assert(prevItem1 < offset.Item1);
+                        Debug.Assert(prevItem2 < offset.Item2);
+                    }
                     writer.WriteStartElement("IL");
 
                     writer.WriteElementString("CLR", "0x" + offset.Item1.ToString("X8", CultureInfo.InvariantCulture));
                     writer.WriteElementString("nanoCLR", "0x" + offset.Item2.ToString("X8", CultureInfo.InvariantCulture));
+
+                    prevItem1 = offset.Item1;
+                    prevItem2 = offset.Item2;
 
                     writer.WriteEndElement();
                 }

--- a/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
+++ b/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
@@ -219,6 +219,9 @@ namespace nanoFramework.Tools.MetadataProcessor
 
                 interfacesToRemove.Select(i => c.Interfaces.Remove(i)).ToList();
             }
+
+            // flag minimize completed
+            _tablesContext.MinimizeComplete = true;
         }
 
         private void ShowDependencies(MetadataToken token, HashSet<MetadataToken> set, HashSet<MetadataToken> setTmp)


### PR DESCRIPTION
- Byte code table is now generated only after minimize step (output was wrong because the second pass was working on the already tweaked offsets table).
- Add asserts in PDBX generator.
- Update console test app.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>