### PR TITLE
Fix parameterIndex increment in skeleton generator for Interop

### DIFF
--- a/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
+++ b/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
@@ -182,8 +182,8 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                                             parameterDeclaration.Declaration = $"{parameterType} {parameterDeclaration.Name};";
                                             parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{parameterType}( stack, {(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
                                        }
-
                                         newMethod.ParameterDeclaration.Add(parameterDeclaration);
+                                        parameterIndex++;
                                     }
 
                                     declaration.Append("HRESULT &hr )");


### PR DESCRIPTION
Otherwise, we will keep using param0 for every generated parameter instead of using param{n} per loop run.

Discussed on Discord.

Signed-by: Thomas Karl Pietrowski <thopiekar@github.com> (github: thopiekar)