### PR TITLE
Fix marshalling declaration using CLR types in skeleton generator

### DIFF
--- a/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
+++ b/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
@@ -135,6 +135,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                                     {
                                         // get the parameter type
                                         var parameterType = item.ParameterType.ToNativeTypeAsString();
+                                        var parameterTypeClr = item.ParameterType.ToCLRTypeAsString();
 
                                         // compose the function declaration
                                         declaration.Append($"{parameterType} param{parameterIndex.ToString()}, ");
@@ -161,26 +162,26 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                                                 $"{parameterType} {parameterDeclaration.Name};" + Environment.NewLine +
                                                 $"        UINT8 heapblock{parameterIndex.ToString()}[CLR_RT_HEAP_BLOCK_SIZE];";
 
-                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{parameterType}_ByRef( stack, heapblock{(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
+                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{parameterTypeClr}_ByRef( stack, heapblock{(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
 
                                         }
                                         else if (item.ParameterType.IsArray)
                                         {
                                             // declaration like
-                                            // Interop_Marshal_INT8_ARRAY param0;
+                                            // CLR_RT_TypedArray_UINT8 param0;
 
                                             parameterDeclaration.Type = parameterType;
                                             parameterDeclaration.Declaration = $"{parameterType} {parameterDeclaration.Name};";
-                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{item.ParameterType.GetElementType().ToCLRTypeAsString()}_ARRAY( stack, {(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
+                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{parameterTypeClr}_ARRAY( stack, {(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
                                         }
                                         else
                                         {
                                             // declaration like
-                                            // Interop_Marshal_INT8 param1;
+                                            // INT8 param1;
 
                                             parameterDeclaration.Type = parameterType;
                                             parameterDeclaration.Declaration = $"{parameterType} {parameterDeclaration.Name};";
-                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{item.ParameterType.ToCLRTypeAsString()}( stack, {(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
+                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{parameterTypeClr}( stack, {(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
                                        }
                                         newMethod.ParameterDeclaration.Add(parameterDeclaration);
                                         parameterIndex++;

--- a/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
+++ b/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
@@ -167,7 +167,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                                         else if (item.ParameterType.IsArray)
                                         {
                                             // declaration like
-                                            // CLR_RT_TypedArray_UINT8 param0;
+                                            // Interop_Marshal_INT8_ARRAY param0;
 
                                             parameterDeclaration.Type = parameterType;
                                             parameterDeclaration.Declaration = $"{parameterType} {parameterDeclaration.Name};";
@@ -176,11 +176,11 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                                         else
                                         {
                                             // declaration like
-                                            // INT8 param1;
+                                            // Interop_Marshal_INT8 param1;
 
                                             parameterDeclaration.Type = parameterType;
                                             parameterDeclaration.Declaration = $"{parameterType} {parameterDeclaration.Name};";
-                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{parameterType}( stack, {(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
+                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{item.ParameterType.GetElementType().ToCLRTypeAsString()}( stack, {(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
                                        }
                                         newMethod.ParameterDeclaration.Add(parameterDeclaration);
                                         parameterIndex++;

--- a/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
+++ b/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
@@ -180,7 +180,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
 
                                             parameterDeclaration.Type = parameterType;
                                             parameterDeclaration.Declaration = $"{parameterType} {parameterDeclaration.Name};";
-                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{item.ParameterType.GetElementType().ToCLRTypeAsString()}( stack, {(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
+                                            parameterDeclaration.MarshallingDeclaration = $"Interop_Marshal_{item.ParameterType.ToCLRTypeAsString()}( stack, {(parameterIndex + (m.IsStatic ? 0 : 1)).ToString()}, {parameterDeclaration.Name} )";
                                        }
                                         newMethod.ParameterDeclaration.Add(parameterDeclaration);
                                         parameterIndex++;


### PR DESCRIPTION
Just noticed that the name of the array's type doesn't fit to the comment above it.
Additionally, I (hopefully) fixed an issue with the type generation for regular data types.
However, I haven't tested these changes practically.

Signed-by: Thomas Karl Pietrowski <thopiekar@gmail.com> (github: thopiekar)