### PR TITLE
Add processing to update native methods CRC32

### DIFF
--- a/source/MetadataProcessor.Core/nanoAssemblyDefinition.cs
+++ b/source/MetadataProcessor.Core/nanoAssemblyDefinition.cs
@@ -5,6 +5,7 @@
 //
 
 using System.IO;
+using System.Linq;
 
 namespace nanoFramework.Tools.MetadataProcessor
 {
@@ -89,8 +90,20 @@ namespace nanoFramework.Tools.MetadataProcessor
             // keeping this here for now, just for compatibility
             writer.WriteUInt32(0);
 
+            var nativeMethdodsCount = _context.MethodDefinitionTable.Items.Count(method => method.RVA == 0 && !method.IsAbstract);
+
             // native methods CRC32
-            writer.WriteUInt32(_context.NativeMethodsCrc.Current);
+            // this is used by other tools to check if the assembly has native implementation 
+            // (like the deployment provider in the VS extension)
+            if (nativeMethdodsCount > 0)
+            {
+                writer.WriteUInt32(_context.NativeMethodsCrc.Current);
+            }
+            else
+            {
+                // this assembly doesn't have any native methods implemented
+                writer.WriteUInt32(0);
+            }
 
             // Native methods offset
             writer.WriteUInt32(0xFFFFFFFF);


### PR DESCRIPTION
- This is required to mark to other tools if the assembly required native support. Interop libraries require native support to be present on the target. With this change the NativeMethodsCheckSum position in the PE can now be used to signal this. When the value it's 0, the assembly does not hava native implementation.

- Addresses nanoframework/Home#575.


Signed-off-by: josesimoes <jose.simoes@eclo.solutions>