### PR TITLE
Fix checking for class inclusion in typedef extension

### DIFF
--- a/source/MetadataProcessor.Core/Extensions/TypeDefinitionExtensions.cs
+++ b/source/MetadataProcessor.Core/Extensions/TypeDefinitionExtensions.cs
@@ -19,9 +19,11 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
                 return false;
             }
 
+            typeDefFlags = typeDefFlags & nanoTypeDefinitionFlags.TD_Semantics;
+
             // Only generate a stub for classes and value types.
-            if ( typeDefFlags.HasFlag(nanoTypeDefinitionFlags.TD_Semantics_Class) ||
-                 typeDefFlags.HasFlag(nanoTypeDefinitionFlags.TD_Semantics_ValueType) )
+            if  (typeDefFlags == nanoTypeDefinitionFlags.TD_Semantics_Class ||
+                 typeDefFlags == nanoTypeDefinitionFlags.TD_Semantics_ValueType )
             { 
                 return true;
             }


### PR DESCRIPTION
- Can't use `HasFlags` because of the need to reuse the C++ flags structure which is not well replicable in C#.
- Fixes nanoFramework/Home#588.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>