### PR TITLE
Fix signature generator for array elements

### DIFF
--- a/source/MetadataProcessor.Core/Tables/nanoSignaturesTable.cs
+++ b/source/MetadataProcessor.Core/Tables/nanoSignaturesTable.cs
@@ -449,8 +449,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             using (var buffer = new MemoryStream())
             using (var writer = new BinaryWriter(buffer))
             {
-                writer.Write((byte)defaultValue.Length);
-                writer.Write((byte)0x00); // TODO: investigate this temporary fix
+                writer.Write((ushort)defaultValue.Length);
                 writer.Write(defaultValue);
 
                 return buffer.ToArray();


### PR DESCRIPTION
## Description
- Fix code generating signature for array elements. The original code had a workaround to fix the signature length which was producing a wrong output for arrays larger than 255 elements.

## Motivation and Context
- Fixes nanoFramework/Home#552.
- Fixes nanoFramework/Home#595.

## How Has This Been Tested?<!-- (if applicable) -->
- Test app in the issue above.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>