### PR TITLE
Fix minize step for CustomAttributes in dependency collection

### DIFF
--- a/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
+++ b/source/MetadataProcessor.Core/nanoAssemblyBuilder.cs
@@ -488,7 +488,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                         if (!nanoTablesContext.ClassNamesToExclude.Contains(c.AttributeType.FullName) && 
                             c.AttributeType.IsToInclude())
                         {
-                            set.Add(c.AttributeType.MetadataToken);
+                            set.Add(c.Constructor.MetadataToken);
                         }
                     }
 


### PR DESCRIPTION
## Description

nanoAttributesTable.RemoveUnusedItems() uses attribute.Constructor.MetadataToken for checks while nanoAssemblyBuilder put attribute.AttributeType.MetadataToken into dependency list.
This results in losing class attributes.
(While processing field and method attributes both components use constructor.MetadataToken)

## Motivation and Context
- Fixes nanoFramework/Home#599

## How Has This Been Tested?
Debug trace.

## Types of changes
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Signed-off-by: SandorDobos <dbs.sndr@gmail.com>
