### PR TITLE
Fix TypeRef ID calculation for TypeSpec entry

### DIFF
--- a/source/MetadataProcessor.Core/Mono.Cecil/CodeWriter.cs
+++ b/source/MetadataProcessor.Core/Mono.Cecil/CodeWriter.cs
@@ -473,6 +473,8 @@ namespace nanoFramework.Tools.MetadataProcessor
             if(typeReference is TypeSpecification)
             {
                 referenceId = _context.TypeSpecificationsTable.GetOrCreateTypeSpecificationId(typeReference);
+
+                return (ushort)(0x8000 | referenceId);
             }
             else if (_context.TypeReferencesTable.TryGetTypeReferenceId(typeReference, out referenceId))
             {


### PR DESCRIPTION
## Description
- Fix calculation of TypeDef id for TypeSpec entries.

## Motivation and Context
- Fixes nanoFramework/Home#592.

## How Has This Been Tested?<!-- (if applicable) -->
- Sample code in the issue. Compared with output from old MDP.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
