### PR TITLE
Fix assembly resolution

### DIFF
--- a/source/MetadataProcessor.Core/Utility/LoadHintsAssemblyResolver.cs
+++ b/source/MetadataProcessor.Core/Utility/LoadHintsAssemblyResolver.cs
@@ -12,9 +12,8 @@ using System.Reflection;
 namespace nanoFramework.Tools.MetadataProcessor
 {
     /// <summary>
-    /// Implements special external .NET nanoFramework assemblies resolution logic.
-    /// MetadataTransformer gets maps with pair assembly name and assebly path in command line,
-    /// if we unable to load assemlby using default resolver we will try to use this map.
+    /// Need to use .NET nanoFramework assemblies for resolution.
+    /// When calling MDP it's required to provide load hints with pairs of assembly name and assebly path.
     /// </summary>
     public sealed class LoadHintsAssemblyResolver : BaseAssemblyResolver
     {
@@ -38,36 +37,37 @@ namespace nanoFramework.Tools.MetadataProcessor
         {
             try
             {
-                return base.Resolve(name);
-            }
-            catch (Exception)
-            {
-                string assemblyFileName;
-                if (_loadHints.TryGetValue(name.Name, out assemblyFileName))
+                if (_loadHints.TryGetValue(name.Name, out string assemblyFileName))
                 {
                     return AssemblyDefinition.ReadAssembly(assemblyFileName);
                 }
-
+                else
+                {
+                    return null;
+                }
+            }
+            catch (Exception)
+            {
                 throw;
             }
         }
-
        
         /// <inheritdoc/>
         public override AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
         {
             try
             {
-                return base.Resolve(name, parameters);
-            }
-            catch (Exception)
-            {
-                string assemblyFileName;
-                if (_loadHints.TryGetValue(new AssemblyName(name.FullName).Name, out assemblyFileName))
+                if (_loadHints.TryGetValue(new AssemblyName(name.FullName).Name, out string assemblyFileName))
                 {
                     return AssemblyDefinition.ReadAssembly(assemblyFileName);
                 }
-
+                else
+                {
+                    return null;
+                }
+            }
+            catch (Exception)
+            {
                 throw;
             }
         }


### PR DESCRIPTION
## Description
- Assembly resolution now uses exclusively the assemblies provided by load hints, not the ones from the full .NET framework.

## Motivation and Context
- Using the .NET framework assemblies (like mscorlib) was wrong and lead to potential errors by using types from assemblies other than nF ones.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
