### PR TITLE
Fix indexing of class fields for derived classes

### DIFF
--- a/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
+++ b/source/MetadataProcessor.Core/nanoSkeletonGenerator.cs
@@ -557,26 +557,14 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                 fieldCount = GetNestedFieldsCount(c.BaseType.Resolve());
 
                 // now add the fields count from this type
-                if (_tablesContext.TypeDefinitionTable.TryGetTypeReferenceId(c, out tt))
-                {
-                    fieldCount += c.Fields.Count(f => !f.IsStatic && !f.IsLiteral);
-                }
+                fieldCount += c.Fields.Count(f => !f.IsStatic && !f.IsLiteral);
 
                 return fieldCount;
             }
             else
             {
                 // get the fields count from this type
-
-                if (_tablesContext.TypeDefinitionTable.TryGetTypeReferenceId(c, out tt))
-                {
-                    return c.Fields.Count(f => !f.IsStatic && !f.IsLiteral);
-                }
-                else
-                {
-                    // can't find this type in the table
-                    return 0;
-                }
+                return c.Fields.Count(f => !f.IsStatic && !f.IsLiteral);
             }
         }
     }


### PR DESCRIPTION
## Description
- Fix algorithm to find count of class fields when class is a derived one.

## Motivation and Context
- The calculation was wrong when the base type was from a different assembly.

## How Has This Been Tested?<!-- (if applicable) -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: josesimoes <jose.simoes@eclo.solutions>
