### PR TITLE
Fix filtering member references

### DIFF
--- a/MetadataProcessor.Core/Tables/nanoTablesContext.cs
+++ b/MetadataProcessor.Core/Tables/nanoTablesContext.cs
@@ -113,7 +113,9 @@ namespace nanoFramework.Tools.MetadataProcessor
                 StringComparer.Ordinal);
 
             var memberReferences = mainModule.GetMemberReferences()
-                .Where(item => typeReferencesNames.Contains(item.DeclaringType.FullName))
+                .Where(item => 
+                    (typeReferencesNames.Contains(item.DeclaringType.FullName) || 
+                    item.DeclaringType.GetElementType().IsPrimitive))
                 .ToList();
 
             FieldReferencesTable = new nanoFieldReferenceTable(


### PR DESCRIPTION
## Description
- Improve filtering of MemberReferences to include primitive types of arrays.

## Motivation and Context
- Filter was wrongly ignoring primitive types of multidimensional arrays.
- Fixes nanoFramework/Home#629.

## How Has This Been Tested?<!-- (if applicable) -->
- Successfull compilation of application with array as mentioned in the issue.

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
