### PR TITLE
Add support to process methods with generics <T> in parameters and as return type

### DIFF
--- a/MetadataProcessor.Core/Extensions/MethodDefinitionExtensions.cs
+++ b/MetadataProcessor.Core/Extensions/MethodDefinitionExtensions.cs
@@ -1,0 +1,40 @@
+//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using Mono.Cecil;
+using System.Linq;
+using System.Text;
+
+namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
+{
+    internal static class MethodDefinitionExtensions
+    {
+        public static string FullName(this MethodDefinition value)
+        {
+            if(value.GenericParameters.Count == 0)
+            {
+                return value.Name;
+            }
+            else
+            {
+                StringBuilder name = new StringBuilder(value.Name);
+                name.Append("<");
+
+                foreach(var p in value.GenericParameters)
+                {
+                    name.Append(p.Name);
+                    if (!p.Equals(value.GenericParameters.Last()))
+                    {
+                        name.Append(",");
+                    }
+                }
+
+                name.Append(">");
+
+                return name.ToString();
+            }
+        }
+    }
+}

--- a/MetadataProcessor.Core/Extensions/TypeReferenceExtensions.cs
+++ b/MetadataProcessor.Core/Extensions/TypeReferenceExtensions.cs
@@ -97,6 +97,14 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
                 return byrefSig.ToString();
             }
 
+            if (type.IsGenericParameter)
+            {
+                StringBuilder genericSig = new StringBuilder(type.Name);
+                genericSig.Append(type.GetElementType().TypeSignatureAsString());
+
+                return genericSig.ToString();
+            }
+
             return "";
         }
 
@@ -165,6 +173,10 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
                 return arraySig.ToString();
             }
 
+            if (type.IsGenericParameter)
+            {
+                return "TGeneric";
+            }
             return "";
         }
 
@@ -232,6 +244,11 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
                 arraySig.Append("_ARRAY");
 
                 return arraySig.ToString();
+            }
+
+            if (type.IsGenericParameter)
+            {
+                return "TGeneric";
             }
 
             return "";

--- a/MetadataProcessor.Core/Extensions/TypeReferenceExtensions.cs
+++ b/MetadataProcessor.Core/Extensions/TypeReferenceExtensions.cs
@@ -99,10 +99,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
 
             if (type.IsGenericParameter)
             {
-                StringBuilder genericSig = new StringBuilder(type.Name);
-                genericSig.Append(type.GetElementType().TypeSignatureAsString());
-
-                return genericSig.ToString();
+                return $"!!{type.Name}";
             }
 
             return "";

--- a/MetadataProcessor.Core/Extensions/TypeReferenceExtensions.cs
+++ b/MetadataProcessor.Core/Extensions/TypeReferenceExtensions.cs
@@ -175,7 +175,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
 
             if (type.IsGenericParameter)
             {
-                return "TGeneric";
+                return "UNSUPPORTED";
             }
             return "";
         }
@@ -248,7 +248,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
 
             if (type.IsGenericParameter)
             {
-                return "TGeneric";
+                return "UNSUPPORTED";
             }
 
             return "";

--- a/MetadataProcessor.Core/MetadataProcessor.Core.csproj
+++ b/MetadataProcessor.Core/MetadataProcessor.Core.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Endianness\nanoBinaryWriter.cs" />
     <Compile Include="Extensions\ParameterDefintionExtensions.cs" />
     <Compile Include="Extensions\ByteArrayExtensions.cs" />
+    <Compile Include="Extensions\MethodDefinitionExtensions.cs" />
     <Compile Include="Extensions\TypeReferenceExtensions.cs" />
     <Compile Include="Extensions\TypeDefinitionExtensions.cs" />
     <Compile Include="InanoTable.cs" />

--- a/MetadataProcessor.Core/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Core/Tables/nanoSignaturesTable.cs
@@ -342,6 +342,12 @@ namespace nanoFramework.Tools.MetadataProcessor
                 return;
             }
 
+            if (typeDefinition.IsGenericParameter || typeDefinition.IsGenericInstance)
+            {
+                writer.WriteByte((byte)nanoCLR_DataType.DATATYPE_GENERIC);
+                return;
+            }
+
             writer.WriteByte(0x00);
         }
 

--- a/MetadataProcessor.Core/Utility/NativeMethodsCrc.cs
+++ b/MetadataProcessor.Core/Utility/NativeMethodsCrc.cs
@@ -183,8 +183,18 @@ namespace nanoFramework.Tools.MetadataProcessor
             }
             else
             {
-                // type is not primitive, get full qualified type name
-                return parameterType.FullName.Replace(".", String.Empty);
+                // type is not primitive
+                
+                if (parameterType.IsGenericParameter)
+                {
+                    // check if it's generic
+                    return "DATATYPE_GENERICTYPE";
+                }
+                else
+                { 
+                    // this is not a generic, get full qualified type name
+                    return parameterType.FullName.Replace(".", String.Empty);
+                }
             }
         }
 

--- a/MetadataProcessor.Core/Utility/nanoCLR_DataType.cs
+++ b/MetadataProcessor.Core/Utility/nanoCLR_DataType.cs
@@ -47,6 +47,7 @@ namespace nanoFramework.Tools.MetadataProcessor
         DATATYPE_LAST_PRIMITIVE = DATATYPE_STRING,
 
         DATATYPE_OBJECT, // Shortcut for System.Object
+        DATATYPE_GENERIC = DATATYPE_OBJECT,
         DATATYPE_CLASS, // CLASS <class Token>
         DATATYPE_VALUETYPE, // VALUETYPE <class Token>
         DATATYPE_SZARRAY, // Shortcut for single dimension zero lower bound array SZARRAY <type>

--- a/MetadataProcessor.Core/nanoDumperGenerator.cs
+++ b/MetadataProcessor.Core/nanoDumperGenerator.cs
@@ -247,7 +247,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     var methodDef = new MethodDef()
                     {
                         ReferenceId = m.MetadataToken.ToInt32().ToString("x8"),
-                        Name = m.Name,
+                        Name = m.FullName(),
                         RVA = m.RVA.ToString("x8"),
                         Implementation = "00000000",
                         Signature = PrintSignatureForMethod(m)


### PR DESCRIPTION
## Description
A method of signature
```
 T Do<T>();
```
was being generated as
```
void Do<T>();
```
which causes the runtime not to copy the result on the returning function stack to its caller stack, thereby corrupting the stack and crashing.
This changes allows the returned generic parameter and instance to be generated as object rather than void


## Motivation and Context
This is meant to open opportunities to advance C# techniques, especially async

## How Has This Been Tested?<!-- (if applicable) -->
Using the console app to generate a PE for an assembly containing generics and loading the generated PE on nanoCLR

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/master/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
