### PR TITLE
Add edge case with referencing enums in another assembly

### DIFF
--- a/MetadataProcessor.Tests/Core/Utility/DumperTests.cs
+++ b/MetadataProcessor.Tests/Core/Utility/DumperTests.cs
@@ -41,9 +41,9 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             Assert.IsTrue(dumpFileContent.Contains("TypeRefProps [01000001]: Scope: 23000001 'System.Diagnostics.DebuggableAttribute'"));
             Assert.IsTrue(dumpFileContent.Contains(": Scope: 23000002 'TestNFClassLibrary.ClassOnAnotherAssembly'"));
 
-            Assert.IsTrue(dumpFileContent.Contains(": Flags: 00001001 Extends: 0100000d Enclosed: 02000000 'TestNFApp.DummyCustomAttribute1'"));
+            Assert.IsTrue(dumpFileContent.Contains(": Flags: 00001001 Extends: 0100000f Enclosed: 02000000 'TestNFApp.DummyCustomAttribute1'"));
 
-            Assert.IsTrue(dumpFileContent.Contains(": Flags: 00001001 Extends: 0100000d Enclosed: 02000000 'TestNFApp.DummyCustomAttribute2'"));
+            Assert.IsTrue(dumpFileContent.Contains(": Flags: 00001001 Extends: 0100000f Enclosed: 02000000 'TestNFApp.DummyCustomAttribute2'"));
 
             Assert.IsTrue(dumpFileContent.Contains(": Flags: 00001061 Extends: 01000000 Enclosed: 02000000 'TestNFApp.IOneClassOverAll'"));
             Assert.IsTrue(dumpFileContent.Contains(": Flags: 000007c6 Impl: 00000000 RVA: 00000000 'get_DummyProperty' [I4(   )]"));

--- a/MetadataProcessor.Tests/TestNFApp/Program.cs
+++ b/MetadataProcessor.Tests/TestNFApp/Program.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using TestNFClassLibrary;
 
@@ -35,6 +36,26 @@ namespace TestNFApp
             /////////////////////////////
             // Reflection Tests
             ReflectionTests();
+
+            ////////////////////////////////////////////////
+            // Test enum in another assembly, same namespace
+            var enumTest = new TestEnumInAnotherAssembly();
+            enumTest.CallTestEnumInAnotherAssembly();
+
+            /////////////////////////////////////
+            // reference enum in another assembly
+            var x = (IAmAClassWithAnEnum.EnumA)1;
+
+            var messageType = (IAmAClassWithAnEnum.EnumA)0;
+            switch (messageType)
+            {
+                case IAmAClassWithAnEnum.EnumA.Test:
+                    Console.WriteLine("all good");
+                    break;
+
+                default:
+                    break;
+            }
 
             Debug.WriteLine("Exiting TestNFApp");
         }

--- a/MetadataProcessor.Tests/TestNFApp/TestEnumInAnotherAssembly.cs
+++ b/MetadataProcessor.Tests/TestNFApp/TestEnumInAnotherAssembly.cs
@@ -1,0 +1,20 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace System.IO
+{
+    public class TestEnumInAnotherAssembly
+    {
+        public void CallTestEnumInAnotherAssembly()
+        {
+            // This test checks if MDP can minimize the assembly using an enum that is defined in another assembly
+            // and the class calling it is in a different assembly BUT in the same namespace.
+            var ioException = new IOException(
+                    string.Empty,
+                    (int)IOException.IOExceptionErrorCode.DirectoryNotFound);
+        }
+    }
+
+}

--- a/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
+++ b/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
@@ -26,6 +26,7 @@
     <Compile Include="IOneClassOverAll.cs" />
     <Compile Include="ComplexAttribute.cs" />
     <Compile Include="MaxAttribute.cs" />
+    <Compile Include="TestEnumInAnotherAssembly.cs" />
     <Compile Include="MyAttribute.cs" />
     <Compile Include="MyClass1.cs" />
     <Compile Include="OneClassOverAll.cs" />

--- a/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmAClassWithAnEnum.cs
+++ b/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmAClassWithAnEnum.cs
@@ -1,0 +1,15 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace TestNFClassLibrary
+{
+    public class IAmAClassWithAnEnum
+    {
+        public enum EnumA
+        {
+            Test = 1
+        }
+    }
+}

--- a/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/TestNFClassLibrary.nfproj
+++ b/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/TestNFClassLibrary.nfproj
@@ -18,6 +18,7 @@
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="IAmAClassWithAnEnum.cs" />
     <Compile Include="ClassOnAnotherAssembly.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
## Description
- Dependency crawler now properly finds usage of enums from other assemblies.
- Add edge case to Unit Test test app.
- Update dumper unit test because of new types added.

## Motivation and Context
- Fixes edge case with enums from other assemblies being wrongly stripped out during minimization.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests.
- Succesfully building nanoframework/System.IO.FileSystem#98 which was failing with "Exception minimizing assembly: Can't find entry in type reference table for System.IO.IOException/IOExceptionErrorCode"

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
