### PR TITLE
Fix Log output messages

### DIFF
--- a/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
+++ b/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
@@ -119,7 +119,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
         public override bool Execute()
         {
             // report to VS output window what step the build is 
-            Log.LogCommandLine(MessageImportance.Normal, "Starting nanoFramework MetadataProcessor...");
+            Log.LogCommandLine(MessageImportance.Normal, "Starting nanoFramework MetadataProcessor..");
 
             /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
             // developer note: to debug this task set an environment variable like this:
@@ -137,7 +137,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                 if (LoadHints != null &&
                     LoadHints.Any())
                 {
-                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Processing load hints...");
+                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Processing load hints..");
 
                     foreach (var hint in LoadHints)
                     {
@@ -154,7 +154,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                 if (ExcludeClassByName != null &&
                     ExcludeClassByName.Any())
                 {
-                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Processing class exclusion list...");
+                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Processing class exclusion list..");
 
                     foreach (var className in ExcludeClassByName)
                     {
@@ -167,7 +167,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                 // Analyses a .NET assembly
                 if (!string.IsNullOrEmpty(Parse))
                 {
-                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, $"Analysing .NET assembly {Path.GetFileNameWithoutExtension(Parse)}...");
+                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, $"Analysing .NET assembly {Path.GetFileNameWithoutExtension(Parse)}..");
 
                     ExecuteParse(Parse);
                 }
@@ -183,7 +183,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                     }
                     else
                     {
-                        if (Verbose) Log.LogCommandLine(MessageImportance.Normal, $"Compiling {Path.GetFileNameWithoutExtension(Compile)} into nanoCLR format...");
+                        if (Verbose) Log.LogCommandLine(MessageImportance.Normal, $"Compiling {Path.GetFileNameWithoutExtension(Compile)} into nanoCLR format..");
 
                         ExecuteCompile(Compile);
                     }
@@ -280,14 +280,14 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
         {
             try
             {
-                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Parsing assembly...");
+                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Parsing assembly..");
 
                 _assemblyDefinition = AssemblyDefinition.ReadAssembly(fileName,
                     new ReaderParameters { AssemblyResolver = new LoadHintsAssemblyResolver(_loadHints) });
             }
             catch (Exception)
             {
-                Log.LogError($"Unable to parse input assembly file '{fileName}' - check if path and file exists.");
+                Log.LogError($"Unable to parse input assembly file '{fileName}' - check if path and file exists");
             }
         }
 
@@ -297,7 +297,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
             try
             {
                 // compile assembly (1st pass)
-                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Compiling assembly...");
+                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Compiling assembly..");
 
                 _assemblyBuilder = new nanoAssemblyBuilder(
                     _assemblyDefinition,
@@ -313,7 +313,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
             }
             catch (Exception)
             {
-                Log.LogError($"Unable to compile output assembly file '{fileName}' - check parse command results.");
+                Log.LogError($"Unable to compile output assembly file '{fileName}' - check parse command results");
 
                 throw;
             }
@@ -324,12 +324,12 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                 File.Delete(Path.ChangeExtension(fileName, "tmp"));
 
                 // minimize (has to be called after the 1st compile pass)
-                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Minimizing assembly...");
+                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Minimizing assembly..");
 
                 _assemblyBuilder.Minimize();
 
                 // compile assembly (2nd pass after minimize)
-                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Recompiling assembly...");
+                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Recompiling assembly..");
 
                 using (var stream = File.Open(fileName, FileMode.Create, FileAccess.ReadWrite))
                 using (var writer = new BinaryWriter(stream))
@@ -346,7 +346,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                 // output assembly metadata
                 if (DumpMetadata)
                 {
-                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Dumping assembly metadata...");
+                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Dumping assembly metadata..");
 
                     DumpFile = Path.ChangeExtension(fileName, "dump.txt");
 
@@ -364,11 +364,11 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
             }
             catch (ArgumentException ex)
             {
-                Log.LogError($"Exception minimizing assembly: {ex.Message}.");
+                Log.LogError($"Exception minimizing assembly: {ex.Message}");
             }
             catch (Exception)
             {
-                Log.LogError($"Exception minimizing assembly.");
+                Log.LogError($"Exception minimizing assembly");
                 throw;
             }
         }
@@ -387,7 +387,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
         {
             try
             {
-                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Generating skeleton files...");
+                if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Generating skeleton files..");
 
                 var skeletonGenerator = new nanoSkeletonGenerator(
                     _assemblyBuilder.TablesContext,
@@ -424,7 +424,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
             }
             catch (Exception)
             {
-                Log.LogError($"Unable to generate and write dependency graph for assembly file '{fileName}'.");
+                Log.LogError($"Unable to generate and write dependency graph for assembly file '{fileName}'");
 
                 throw;
             }

--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -713,7 +713,16 @@ namespace nanoFramework.Tools.MetadataProcessor
                         {
                             if (v.VariableType.DeclaringType != null)
                             {
-                                set.Add(v.VariableType.DeclaringType.MetadataToken);
+                                var resolvedType = v.VariableType.Resolve();
+
+                                if (resolvedType != null && resolvedType.IsEnum)
+                                {
+                                    set.Add(v.VariableType.MetadataToken);
+                                }
+                                else
+                                {
+                                    set.Add(v.VariableType.DeclaringType.MetadataToken);
+                                }
                             }
                             else if (v.VariableType.MetadataType == MetadataType.Class)
                             {


### PR DESCRIPTION
## Description
- Remove trailing dot which is added by VS output.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
