### PR TITLE
Add check for string table size

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoStringTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoStringTable.cs
@@ -99,6 +99,13 @@ namespace nanoFramework.Tools.MetadataProcessor
                 id = _lastAvailableId;
                 _idsByStrings.Add(value, id);
                 var length = Encoding.UTF8.GetBytes(value).Length + 1;
+
+                // sanity check for ID overflow
+                if (_lastAvailableId + length > ushort.MaxValue)
+                {
+                    throw new InvalidOperationException($"String table overflow in assembly '{_context.AssemblyDefinition.Name}'. Can't use so many strings.");
+                }
+
                 _lastAvailableId += (ushort)(length);
             }
             return id;


### PR DESCRIPTION
## Description
- Add check for string table size. Now throws exception when overflowing.

## Motivation and Context
- Resolves issue with assemblies containing many strings which causes an overflow of the string ID. Because of the metadata token limits of .NET nanoFramework, the ID is limited to 65535. Before this, there was no check and the ID was overflowing which caused unwanted results.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Parsing a project with a huge number of strings.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
