### PR TITLE
Add publishing of NuGet package with CLI version

### DIFF
--- a/MetadataProcessor.Console/Program.cs
+++ b/MetadataProcessor.Console/Program.cs
@@ -213,7 +213,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                 {
                     System.Console.WriteLine("");
                     System.Console.WriteLine("-parse <path-to-assembly-file>                        Analyses .NET assembly.");
-                    System.Console.WriteLine("-compile <path-to-PE-file>                            Compiles an assembly into nanoCLR format. Optionally flags if this it's a core library.");
+                    System.Console.WriteLine("-compile <path-to-PE-file> <isCoreLibrary>            Compiles an assembly into nanoCLR format and (true/false) if this it's a core library.");
                     System.Console.WriteLine("-loadHints <assembly-name> <path-to-assembly-file>    Loads one (or more) assembly file(s) as a dependency(ies).");
                     System.Console.WriteLine("-excludeClassByName <class-name>                      Removes the class from an assembly.");
                     System.Console.WriteLine("-generateskeleton                                     Generate skeleton files with stubs to add native code for an assembly.");

--- a/MetadataProcessor.Console/package.nuspec
+++ b/MetadataProcessor.Console/package.nuspec
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>nanoFramework.Tools.MetadataProcessor.CLI</id>
+    <title>nanoFramework.Tools.MetadataProcessor.CLI</title>
+    <version>$version$</version>
+    <authors>nanoframework</authors>
+    <description>Command line interface to the Metadata Processor that is used internally by nanoFramework tooling and VS extensions. It is not needed for regular nanoFramework projects, but there are a few use cases where this tool is required.</description>
+    <releaseNotes>
+    </releaseNotes>
+    <readme>docs\README.md</readme>
+    <projectUrl>https://github.com/nanoframework/metadata-processor</projectUrl>
+    <icon>images\nf-logo.png</icon>
+    <license type="file">LICENSE.md</license>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <repository type="git" url="https://github.com/nanoframework/metadata-processor" commit="$commit$" />
+    <copyright>Copyright (c) .NET Foundation and Contributors</copyright>
+    <references></references>
+    <tags>nanoFramework</tags>
+	<contentFiles>
+		<files include="any\any\MetadataProcessor\**" buildAction="None" copyToOutput="true"/>
+	</contentFiles>
+  </metadata>
+  <files>
+    <file src="..\assets\nf-logo.png" target="images\" />
+    <file src="..\LICENSE.md" target="" />
+    <file src="..\README.md" target="docs\" />
+	<!-- Installation via packages.json -->
+    <file src="bin\Release\*.dll" target="content/MetadataProcessor" />
+    <file src="bin\Release\*.exe" target="content/MetadataProcessor" />
+    <file src="bin\Release\*.exe.config" target="content/MetadataProcessor" />
+	<!-- Installation via PackageReference -->
+    <file src="bin\Release\*.dll" target="/contentFiles/any/any/MetadataProcessor" />
+    <file src="bin\Release\*.exe" target="/contentFiles/any/any/MetadataProcessor" />
+    <file src="bin\Release\*.exe.config" target="/contentFiles/any/any/MetadataProcessor" />
+  </files>
+</package>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Is part of .NET **nanoFramework** toolbox, along with other various tools that a
 Version 2.0 is a C# application adapted from the original work of [Oleg Rakhmatulin](@OlegRa).
 Version 1.0 was a Visual C++ application adapted from .NETMF toolbox.
 
+## Using the metadata processor
+
+The metadata processor is available in two packages.
+
+The main use of the metadata processor is packaged as a MSBuild task: [nanoFramework.Tools.MetadataProcessor.MsBuildTask](https://www.nuget.org/packages/nanoFramework.Tools.MetadataProcessor.MsBuildTask). The task is well integrated into the .NET **nanoFramework** build system and is distributed as part of the VS extensions. Almost all use cases can be addressed by the build system as it is, or by setting build variables for, e.g., additional logging.
+
+There are few use cases where the build task cannot be used. E.g., in software that generates source code at runtime, compiles the code via Roslyn, executes it on the virtual device, and uses the output for further processing. The metadata processor is required as a companion to Roslyn to convert the generated .NET assemblies to .NET **nanoFramework** .pe assemblies. The second package, [nanoFramework.Tools.MetadataProcessor.CLI](https://www.nuget.org/packages/nanoFramework.Tools.MetadataProcessor.CLI), contains a CLI version of the tool for this purpose. It is packaged as content: if added to a project, the tool will be distributed with the results of that project. If the package is added to a non-SDK-style project (e.g., .NET Framework project), make sure to set the *Copy to Output Directory* property for the files, as the package manager does not automatically do that. The code in the project should run the CLI with arguments *-loadhints*, *-parse* and *-compile* (in that order!) to create the .pe assembly.
+
 ## Developers guide
 
 ### Cloning the repository

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,7 +225,7 @@ jobs:
     condition: succeeded()
     displayName: Pack NuGet with MetadataProcessor Console
     inputs:
-      command: 'custom' 
+      command: 'custom'
       arguments: 'pack MetadataProcessor.Console\package.nuspec -Version $(NBGV_NuGetPackageVersion) -properties commit="$(Build.SourceVersion)" -properties NoWarn=NU5100'
 
   - task: CopyFiles@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -213,13 +213,13 @@ jobs:
   - script: nbgv cloud -a -c
     condition: succeeded()
     displayName: Set build number
-  
+ 
   - task: PowerShell@2
     condition: succeeded()
     displayName: Save cloud build number
     inputs:
-        targetType: 'inline'
-        script: Write-Host "$("##vso[build.updatebuildnumber]")$env:NBGV_NuGetPackageVersion"
+      targetType: 'inline'
+      script: Write-Host "$("##vso[build.updatebuildnumber]")$env:NBGV_NuGetPackageVersion"
 
   - task: NuGetCommand@2
     condition: succeeded()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,6 +209,25 @@ jobs:
       TargetFolder: '$(Build.ArtifactStagingDirectory)'
       flattenFolders: true
 
+  # set cloud build vars again as they've been overriten by the tests run
+  - script: nbgv cloud -a -c
+    condition: succeeded()
+    displayName: Set build number
+  
+  - task: PowerShell@2
+    condition: succeeded()
+    displayName: Save cloud build number
+    inputs:
+        targetType: 'inline'
+        script: Write-Host "$("##vso[build.updatebuildnumber]")$env:NBGV_NuGetPackageVersion"
+
+  - task: NuGetCommand@2
+    condition: succeeded()
+    displayName: Pack NuGet with MetadataProcessor Console
+    inputs:
+      command: 'custom' 
+      arguments: 'pack MetadataProcessor.Console\package.nuspec -Version $(NBGV_NuGetPackageVersion) -properties commit="$(Build.SourceVersion)" -properties NoWarn=NU5100'
+
   - task: CopyFiles@1
     condition: succeeded()
     displayName: Collecting NuGet package artifact
@@ -255,11 +274,6 @@ jobs:
       targetPath: '$(Build.ArtifactStagingDirectory)'
       artifactName: deployables
 
-  # set cloud build vars again as they've been overriten by the tests run
-  - script: nbgv cloud -a -c
-    condition: succeeded()
-    displayName: Set build number
-  
   # push NuGet packages to NuGet (always happens except on PR builds)
   - task: NuGetCommand@2
     displayName: Push NuGet packages to NuGet


### PR DESCRIPTION
## Description
- Added nuspec for the MDP CLI
- Updated the README.md with a description of the two packages
- Updated the azure pipeline
- Corrected the help text for the MDP console application

The package is named **nanoFramework.Tools.MetadataProcessor.CLI** to emphasize that it is intended to be an *interface* and not a general purpose tool. In the tags only *nanoFramework* is kept, as this is not a tool for the general audience.

In the README.md I've tried to describe the specific use case. I've tried to phrase the text in a way to discourage a regular user to play with this package. I've tried to describe (better?) my use case, where I have unit tests that generate code, compile the code with Roslyn, make a .pe assembly, use nanoclr --loadassemblies and use the output to assert whether a test is successful. This is probably a very niche application, for users who meddle with source generators. 

For this application the content of the package needs to end up in the output (bin) directory of the project that uses the package. The code in the project will use something as Cli.Wrap (nanoFramework.Tools.MetadataProcessor.exe) to convert a *.dll to *.pe file. Hence the package will put the MDP-files in the content directory and not the lib or tools directory.

Unfortunately the way package managers handle content files differs.
- If the project is added to a modern SDK-style project, it is possible to add the files with build action=None and Copy to Output Directory = true.  The package manager expects content files in the contentFiles directory in the package.
- If the project is added to an old-style .NET Framework project, the files are copied from the content directory in the package, the build action is always Content and Copy to Output Directory is not set (hence = false). In the README.md this is described, the Copy to Output Directory must be assigned by hand.

The nuspec supports both package managers, which means that each file is in two locations in the package. This is in line with the recommendations in the description of the NuSpec format.

The azure pipeline is updated. Two steps are taken from the nuspec of the TestFramework. I understand the NuGet command but do not know if the version-related one is applicable. I've also moved a nbgv-command up the list, as I suspect the task must be run before the version is copied to the variable.

## Motivation and Context
See the description for my specific use case. Earlier today I tried that and found that a feature I was using has a different implementation in nF than in .NET. Being able to test the code on a virtual device as part of a unit test very early on in the development cycle saves a lot of time. Any converter from *.dll to *.pe is fine. The MDP.exe is best suited as it already exists, is a console application so there are no problems with package dependencies and framework versions. It does more than needed, but I guess the typical user of this package is smart enough to leave those options alone. 

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- I've used the latest nuget to create the package from the nuspec with the command in the pipeline yaml
- Configured a solution directory to use a directory as nuget source, with the package
- Created two projects, SDK-style and .NET framework, and installed the package.
- Verified that the package is installed as BuildAction=None,Copy=true in the SDK style project. Files are copied to the bin directory.
- Verified that the package is installed as BuildAction=Content,Copy=false in the .NET framework project. Files are copied to the bin directory only after manually setting the Copy To Output Directory.
- Verified that updates of the package are installed in the same way.

I don't know how to test the azure pipeline.

(I did not test the use of the package from the code of the project. I've done that before.)

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
- [ ] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced build process with new tasks for managing build numbers and packing NuGet packages.
	- Introduced a script to set cloud build variables, ensuring accurate versioning post-tests.
	- Added a PowerShell task to save cloud build number for correct versioning in NuGet packages.
	- Implemented a task for packing the NuGet package with appropriate metadata.

These improvements streamline the deployment process and enhance version control in the build pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->