### PR TITLE
Now processes auto backing fields

### DIFF
--- a/MetadataProcessor.Shared/SkeletonGenerator/SkeletonTemplates.cs
+++ b/MetadataProcessor.Shared/SkeletonGenerator/SkeletonTemplates.cs
@@ -67,7 +67,9 @@ struct Library_{{AssemblyName}}_{{Name}}{{#newline}}
 {{#if StaticFields}}{{#newline}}{{/if}}
 
 {{#each InstanceFields}}
-{{#if FieldWarning}}{{FieldWarning}}{{/if}}
+{{#if FieldWarning}}
+    {{FieldWarning}}{{#newline}}
+{{/if}}
     static const int FIELD__{{Name}} = {{ReferenceIndex}};{{#newline}}
 {{/each}}
 {{#if InstanceFields}}{{#newline}}{{/if}}

--- a/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
+++ b/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 
 namespace nanoFramework.Tools.MetadataProcessor.Core
 {
@@ -486,27 +487,27 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     fieldCount = 0;
                     foreach (var f in c.Fields.Where(f => !f.IsStatic && !f.IsLiteral))
                     {
-                        // sanity check for field name
-                        // like auto-vars and such
-                        if (f.Name.IndexOfAny(new char[] { '<', '>' }) > 0)
+                        // rename auto-properties backing field to a valid C++ identifier
+                        string fixedFieldName = string.Empty;
+                        string fieldWarning = string.Empty;
+
+                        if (Regex.IsMatch(f.Name, @"<\w+>k__BackingField"))
+                        {
+                            fixedFieldName = $"{f.Name.Replace("<", "").Replace(">", "_")}";
+                            fieldWarning = $"// auto-property backing field renamed to '{fixedFieldName}'";
+                        }
+
+                        if (_tablesContext.FieldsTable.TryGetFieldReferenceId(f, false, out ushort fieldRefId))
                         {
                             classData.InstanceFields.Add(new InstanceField()
                             {
-                                FieldWarning = $"*** Something wrong with field '{f.Name}'. Possibly its backing field is missing (mandatory for nanoFramework).\n"
+                                Name = string.IsNullOrEmpty(fixedFieldName) ? f.Name : fixedFieldName,
+                                ReferenceIndex = firstInstanceFieldId++,
+                                FieldWarning = fieldWarning
                             });
                         }
-                        else
-                        {
-                            if (_tablesContext.FieldsTable.TryGetFieldReferenceId(f, false, out ushort fieldRefId))
-                            {
-                                classData.InstanceFields.Add(new InstanceField()
-                                {
-                                    Name = f.Name,
-                                    ReferenceIndex = firstInstanceFieldId++
-                                });
-                            }
-                            fieldCount++;
-                        }
+
+                        fieldCount++;
                     }
 
                     // methods


### PR DESCRIPTION
## Description
- Auto generated backing field names is now renamed with valid C++ identifier.
- Update skeleton template with warning comment.

## Motivation and Context
- Compiler generated backing fields for auto properties were producing invalid C++ identifiers in the stubs declaration.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Generating stubs for a class lib with auto generated backing fields.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
