### PR TITLE
Improve processing of custom attributes

### DIFF
--- a/MetadataProcessor.Shared/Extensions/TypeReferenceExtensions.cs
+++ b/MetadataProcessor.Shared/Extensions/TypeReferenceExtensions.cs
@@ -4,15 +4,28 @@
 //
 
 using Mono.Cecil;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
 {
     internal static class TypeReferenceExtensions
     {
+        internal static readonly List<string> NameSpacesToExclude = new List<string>
+        {
+            "System.Diagnostics.CodeAnalysis"
+        };
+
         public static bool IsToInclude(this TypeReference value)
         {
-            return !nanoTablesContext.IgnoringAttributes.Contains(value.FullName);
+            // check list of known attributes to ignore
+            bool ignoreFromList = nanoTablesContext.IgnoringAttributes.Contains(value.FullName);
+
+            // is this attribute in the list of namespaces to exclude
+            bool ignoreFromCodeAnalysis = NameSpacesToExclude.Any(ns => value.FullName.StartsWith(ns));
+
+            return !(ignoreFromList || ignoreFromCodeAnalysis);
         }
 
         public static string TypeSignatureAsString(this TypeReference type)

--- a/MetadataProcessor.Tests/TestNFApp/ClassWithNullAttribs.cs
+++ b/MetadataProcessor.Tests/TestNFApp/ClassWithNullAttribs.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace TestNFApp
+{
+    public class ClassWithNullAttribs
+    {
+        [DoesNotReturn]
+        public int MethodDecoratedWithDoesNotReturn()
+        {
+            throw new Exception();
+        }
+
+        public string MethoWIthParamNotNullAttrib([NotNull] string value)
+        {
+            return value;
+        }
+    }
+}

--- a/MetadataProcessor.Tests/TestNFApp/Program.cs
+++ b/MetadataProcessor.Tests/TestNFApp/Program.cs
@@ -61,6 +61,9 @@ namespace TestNFApp
                     break;
             }
 
+            // null attributes tests
+            _ = new ClassWithNullAttribs();
+
             Debug.WriteLine("Exiting TestNFApp");
         }
 

--- a/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
+++ b/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
@@ -19,6 +19,7 @@
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
     <Compile Include="AuthorAttribute.cs" />
+    <Compile Include="ClassWithNullAttribs.cs" />
     <Compile Include="DataRowAttribute.cs" />
     <Compile Include="DummyCustomAttribute1.cs" />
     <Compile Include="DummyCustomAttribute2.cs" />

--- a/MetadataProcessor.Tests/TestObjectHelper.cs
+++ b/MetadataProcessor.Tests/TestObjectHelper.cs
@@ -192,6 +192,21 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests
 
             return ret;
         }
+
+        public static AssemblyDefinition GetTestNFAppAssemblyDefinitionWithLoadHints()
+        {
+            IDictionary<string, string> loadHints = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["mscorlib"] = GetmscorlibAssemblyDefinition().MainModule.FileName,
+                ["TestNFClassLibrary"] = GetTestNFClassLibraryDefinition().MainModule.FileName
+            };
+
+            return AssemblyDefinition.ReadAssembly(
+                TestNFAppFullPath,
+                new ReaderParameters { AssemblyResolver = new LoadHintsAssemblyResolver(loadHints) });
+        }
+
+
         public static AssemblyDefinition GetTestNFClassLibraryDefinition()
         {
             AssemblyDefinition ret = null;


### PR DESCRIPTION
## Description
- Add new list of namespaces to exclude from metadata.
- `TypeReferenceExtensions.IsToInclude` extension now uses that list along with the classes to exclude.
- Add new class to test app with DoesNotReturn attribute.
- Improve GetTestNFAppAssemblyDefinitionWithLoadHints.
- Add new test for System.Diagnostics.CodeAnalysis attributes.

## Motivation and Context
- Following the addition of several nullable attributes to mscorlib with nanoframework/CoreLibrary/pull/219, and the subsequent release, it was found that decorating a method with the `DoesNotReturn` attribute on an assembly referencing it would cause a type reference missing exception when running the app.
First finding was that the type was excluded from the metadata (on purpose) by adding a `NFMDP_PE_ExcludeClassByName` entry in the project file. Which was correct, in principle, because `DoesNotReturn` class (and friends) are only used by the compiler and have no part in the execution.
All unit tests of mscorlib were all passing, despite some of the methods are decorate with the `DoesNotReturn` attribute, which seem odd at first.

Inspecting the generated IL of `ArgumentNullException.Throw` which is decorated with `DoesNotReturn` attribute:
```console
.method assembly hidebysig static void  Throw(string paramName) cil managed
{
  .custom instance void System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute::.ctor() = ( 01 00 00 00 ) 
  // Code size       7 (0x7)
  .maxstack  8
  IL_0000:  ldarg.0
  IL_0001:  newobj     instance void System.ArgumentNullException::.ctor(string)
  IL_0006:  throw
} // end of method ArgumentNullException::Throw
```

Shows that the compiler adds a custom attribute of this type `System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute`.  ECMA-335 specs state that custom attributes are added to the metadata, which is being honoured by .NET nanoFramework metadata processor.

Adding a unit test validating the absence of this attribute on an assembly using `DoesNotReturn` attribute, fails. Dump file also shows the attribute in the TypeRef table.
Assembly minimization relies on `TypeReferenceExtensions.IsToInclude` which includes a hard coded list of the attributes to automatically exclude. This is the root cause of the type being added to the metadata. Because it was referenced by a custom attribute, despite not being used in any code, it was being added to the TypeRef table.
It's not practical to keep manually adding exclusions to this list. Moreover, it's prone to errors such as in this situation because it was overlooked the need to update the list.
`TypeReferenceExtensions.IsToInclude` was reworked to also check a list of know name spaces whose types are deemed to be automatically excluded from our metadata. `System.Diagnostics.CodeAnalysis` is the first entry there as all types living there are only used by the compiler.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- New unit test added.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
