### PR TITLE
Add sanity check for methods counters

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoTypeDefinitionTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeDefinitionTable.cs
@@ -143,7 +143,12 @@ namespace nanoFramework.Tools.MetadataProcessor
                         }
                     }
 
-                    WriteMethodBodies(item.Methods, item.Interfaces, writer);
+                    WriteMethodBodies(
+                        item.FullName,
+                        item.Methods,
+                        item.Interfaces,
+                        writer
+                    );
 
                     _context.SignaturesTable.WriteDataType(item, writer, false, true, true);
 
@@ -227,6 +232,7 @@ namespace nanoFramework.Tools.MetadataProcessor
         }
 
         private void WriteMethodBodies(
+            string typeName,
             Collection<MethodDefinition> methods,
             Collection<InterfaceImplementation> iInterfaces,
             nanoBinaryWriter writer)
@@ -264,6 +270,22 @@ namespace nanoFramework.Tools.MetadataProcessor
             writer.WriteUInt16(_context.SignaturesTable.GetOrCreateSignatureId(iInterfaces));
 
             writer.WriteUInt16(firstMethodId);
+
+            // sanity checks
+            if (virtualMethodsCount > byte.MaxValue)
+            {
+                throw new InvalidOperationException($"Fatal error processing '{typeName}', virtual methods count ({virtualMethodsCount}) exceeds maximum supported (255).");
+            }
+
+            if (instanceMethodsCount > byte.MaxValue)
+            {
+                throw new InvalidOperationException($"Fatal error processing '{typeName}', instance methods count ({instanceMethodsCount}) exceeds maximum supported (255).");
+            }
+
+            if (staticMethodsCount > byte.MaxValue)
+            {
+                throw new InvalidOperationException($"Fatal error processing '{typeName}', static methods count ({staticMethodsCount}) exceeds maximum supported (255).");
+            }
 
             writer.WriteByte((byte)virtualMethodsCount);
             writer.WriteByte((byte)instanceMethodsCount);


### PR DESCRIPTION
## Description
- Add check for methods count and throwing exception on failure.
- Add parameter with type full name to compose a meaningfully exception message.

## Motivation and Context
- Currently there is no check if these counters overflow the capacity of the metadata storage. This simplistic approach was taken in the (reasonable) assumption that a type wouldn't have more than 255 methods. If this is exceeded (the counter type allows it) the count is truncated producing errors at type resolution stage.
- This was found when running the Iot.Device.Bq2579x sample on a real device. This is the output at device boot:
![image](https://github.com/user-attachments/assets/665b2344-f9fc-48ff-8997-a7d2bd760de6)
The method count for the Bq2579x class is truncated, therefore the type resolution algorithm never finds it.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Processing the Iot.Device.Bq2579x library. Now an exception is thrown.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
