### PR TITLE
Add back CLR integrations tests

### DIFF
--- a/MetadataProcessor.Tests/MetadataProcessor.Tests.csproj
+++ b/MetadataProcessor.Tests/MetadataProcessor.Tests.csproj
@@ -19,6 +19,10 @@
     <TestProjectType>UnitTest</TestProjectType>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <LangVersion>8.0</LangVersion>
+    <NF_MDP_MSBUILDTASK_PATH Condition="'$(NF_MDP_MSBUILDTASK_PATH)' == ''">$(ProjectDir)..\MetadataProcessor.MsBuildTask\bin\$(Configuration)\net472</NF_MDP_MSBUILDTASK_PATH>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -98,6 +102,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="CliWrap">
+      <Version>3.8.0</Version>
+    </PackageReference>
     <PackageReference Include="Mono.Cecil">
       <Version>0.11.6</Version>
     </PackageReference>
@@ -107,10 +114,8 @@
     <PackageReference Include="MSTest.TestFramework">
       <Version>3.7.2</Version>
     </PackageReference>
-    <PackageReference Include="nanoFramework.nanoCLR.Win32" GeneratePathProperty="true">
-      <Version>1.12.3.11</Version>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
+    <PackageReference Include="Newtonsoft.Json">
+      <Version>13.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
@@ -128,8 +133,4 @@
       copy /y "$(ProjectDir)StubsGenerationTestNFApp\$(OutDir)\*" "$(TargetDir)\StubsGenerationTestNFApp"
     </PreBuildEvent>
   </PropertyGroup>
-  <Target Name="SetNFClrLocation" AfterTargets="Build">
-    <Copy SourceFiles="$(PkgnanoFramework_nanoCLR_Win32)\tools\nanoFramework.nanoCLR.exe" DestinationFolder="$(TargetDir)\nanoCLR" SkipUnchangedFiles="false">
-    </Copy>
-  </Target>
 </Project>

--- a/MetadataProcessor.Tests/TestObjectHelper.cs
+++ b/MetadataProcessor.Tests/TestObjectHelper.cs
@@ -3,18 +3,20 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using Mono.Cecil;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using Mono.Cecil;
 
 namespace nanoFramework.Tools.MetadataProcessor.Tests
 {
     public static class TestObjectHelper
     {
+        private const string _varNameForLocalNanoCLRInstancePath = "MDP_TEST_NANOCLR_INSTANCE_PATH";
+
         private static string _testExecutionLocation;
         private static string _testNFAppLocation;
         private static string _nfAppProjectLocation;
@@ -455,5 +457,10 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests
         {
             return typeDefinition.Methods.First(m => m.Name == methodName);
         }
+
+        // no need to check if path exists as this validation is performed by nanoclr
+        public static string NanoClrLocalInstance => Environment.GetEnvironmentVariable(
+            _varNameForLocalNanoCLRInstancePath,
+            EnvironmentVariableTarget.User);
     }
 }


### PR DESCRIPTION
## Description
- Migrate usage of WIN32 virtual device to nanoCLR .NET tool.
- Update CLR integration unit tests to use nanoCLR virtual device.
- Remove dependency of WIN32 nanoCLR in unit test project.

## Motivation and Context
- Need to have these tests back.
- Need to migrate from WIN32 CLR to the new nanoCLR to be able to remove it from the nf-interpreter repo.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running all unit tests.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [x] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
