### PR TITLE
Fix generated metadata in TypeDef processing

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
@@ -1,18 +1,17 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Original work from Oleg Rakhmatulin.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
-using Mono.Cecil;
-using Mono.Cecil.Cil;
-using Mono.Collections.Generic;
-using nanoFramework.Tools.MetadataProcessor.Core.Extensions;
+// Original work from Oleg Rakhmatulin.
+
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+using Mono.Collections.Generic;
+using nanoFramework.Tools.MetadataProcessor.Core.Extensions;
 
 namespace nanoFramework.Tools.MetadataProcessor
 {
@@ -41,35 +40,67 @@ namespace nanoFramework.Tools.MetadataProcessor
             }
         }
 
-        internal static readonly IDictionary<string, nanoCLR_DataType> PrimitiveTypes =
+        private static readonly IDictionary<string, nanoCLR_DataType> s_primitiveTypes =
             new Dictionary<string, nanoCLR_DataType>(StringComparer.Ordinal);
+
+        /// <summary>
+        /// Built-in types (see flags in c_CLR_RT_DataTypeLookup at CLR Core code)
+        /// </summary>
+        private static readonly IDictionary<string, nanoCLR_DataType> s_builtInTypes =
+            new Dictionary<string, nanoCLR_DataType>(StringComparer.Ordinal);
+
+        public static IDictionary<string, nanoCLR_DataType> PrimitiveTypes => s_primitiveTypes;
 
         static nanoSignaturesTable()
         {
-            PrimitiveTypes.Add(typeof(void).FullName, nanoCLR_DataType.DATATYPE_VOID);
+            s_primitiveTypes.Add(typeof(void).FullName, nanoCLR_DataType.DATATYPE_VOID);
 
-            PrimitiveTypes.Add(typeof(sbyte).FullName, nanoCLR_DataType.DATATYPE_I1);
-            PrimitiveTypes.Add(typeof(short).FullName, nanoCLR_DataType.DATATYPE_I2);
-            PrimitiveTypes.Add(typeof(int).FullName, nanoCLR_DataType.DATATYPE_I4);
-            PrimitiveTypes.Add(typeof(long).FullName, nanoCLR_DataType.DATATYPE_I8);
+            s_primitiveTypes.Add(typeof(sbyte).FullName, nanoCLR_DataType.DATATYPE_I1);
+            s_primitiveTypes.Add(typeof(short).FullName, nanoCLR_DataType.DATATYPE_I2);
+            s_primitiveTypes.Add(typeof(int).FullName, nanoCLR_DataType.DATATYPE_I4);
+            s_primitiveTypes.Add(typeof(long).FullName, nanoCLR_DataType.DATATYPE_I8);
 
-            PrimitiveTypes.Add(typeof(byte).FullName, nanoCLR_DataType.DATATYPE_U1);
-            PrimitiveTypes.Add(typeof(ushort).FullName, nanoCLR_DataType.DATATYPE_U2);
-            PrimitiveTypes.Add(typeof(uint).FullName, nanoCLR_DataType.DATATYPE_U4);
-            PrimitiveTypes.Add(typeof(ulong).FullName, nanoCLR_DataType.DATATYPE_U8);
+            s_primitiveTypes.Add(typeof(byte).FullName, nanoCLR_DataType.DATATYPE_U1);
+            s_primitiveTypes.Add(typeof(ushort).FullName, nanoCLR_DataType.DATATYPE_U2);
+            s_primitiveTypes.Add(typeof(uint).FullName, nanoCLR_DataType.DATATYPE_U4);
+            s_primitiveTypes.Add(typeof(ulong).FullName, nanoCLR_DataType.DATATYPE_U8);
 
-            PrimitiveTypes.Add(typeof(float).FullName, nanoCLR_DataType.DATATYPE_R4);
-            PrimitiveTypes.Add(typeof(double).FullName, nanoCLR_DataType.DATATYPE_R8);
+            s_primitiveTypes.Add(typeof(float).FullName, nanoCLR_DataType.DATATYPE_R4);
+            s_primitiveTypes.Add(typeof(double).FullName, nanoCLR_DataType.DATATYPE_R8);
 
-            PrimitiveTypes.Add(typeof(char).FullName, nanoCLR_DataType.DATATYPE_CHAR);
-            PrimitiveTypes.Add(typeof(string).FullName, nanoCLR_DataType.DATATYPE_STRING);
-            PrimitiveTypes.Add(typeof(bool).FullName, nanoCLR_DataType.DATATYPE_BOOLEAN);
+            s_primitiveTypes.Add(typeof(char).FullName, nanoCLR_DataType.DATATYPE_CHAR);
+            s_primitiveTypes.Add(typeof(string).FullName, nanoCLR_DataType.DATATYPE_STRING);
+            s_primitiveTypes.Add(typeof(bool).FullName, nanoCLR_DataType.DATATYPE_BOOLEAN);
 
-            PrimitiveTypes.Add(typeof(object).FullName, nanoCLR_DataType.DATATYPE_OBJECT);
-            PrimitiveTypes.Add(typeof(IntPtr).FullName, nanoCLR_DataType.DATATYPE_I4);
-            PrimitiveTypes.Add(typeof(UIntPtr).FullName, nanoCLR_DataType.DATATYPE_U4);
+            s_primitiveTypes.Add(typeof(object).FullName, nanoCLR_DataType.DATATYPE_OBJECT);
+            s_primitiveTypes.Add(typeof(IntPtr).FullName, nanoCLR_DataType.DATATYPE_I4);
+            s_primitiveTypes.Add(typeof(UIntPtr).FullName, nanoCLR_DataType.DATATYPE_U4);
 
-            PrimitiveTypes.Add(typeof(WeakReference).FullName, nanoCLR_DataType.DATATYPE_WEAKCLASS);
+            s_primitiveTypes.Add(typeof(WeakReference).FullName, nanoCLR_DataType.DATATYPE_WEAKCLASS);
+
+            // from c_CLR_RT_DataTypeLookup at CLR Core code
+            s_builtInTypes.Add(typeof(bool).FullName, nanoCLR_DataType.DATATYPE_BOOLEAN);
+            s_builtInTypes.Add(typeof(char).FullName, nanoCLR_DataType.DATATYPE_CHAR);
+            s_builtInTypes.Add(typeof(sbyte).FullName, nanoCLR_DataType.DATATYPE_I1);
+            s_builtInTypes.Add(typeof(byte).FullName, nanoCLR_DataType.DATATYPE_U1);
+            s_builtInTypes.Add(typeof(short).FullName, nanoCLR_DataType.DATATYPE_I2);
+            s_builtInTypes.Add(typeof(ushort).FullName, nanoCLR_DataType.DATATYPE_U2);
+            s_builtInTypes.Add(typeof(int).FullName, nanoCLR_DataType.DATATYPE_I4);
+            s_builtInTypes.Add(typeof(uint).FullName, nanoCLR_DataType.DATATYPE_U4);
+            s_builtInTypes.Add(typeof(long).FullName, nanoCLR_DataType.DATATYPE_I8);
+            s_builtInTypes.Add(typeof(ulong).FullName, nanoCLR_DataType.DATATYPE_U8);
+            s_builtInTypes.Add(typeof(float).FullName, nanoCLR_DataType.DATATYPE_R4);
+            s_builtInTypes.Add(typeof(double).FullName, nanoCLR_DataType.DATATYPE_R8);
+
+            s_builtInTypes.Add(typeof(DateTime).FullName, nanoCLR_DataType.DATATYPE_DATETIME);
+            s_builtInTypes.Add(typeof(TimeSpan).FullName, nanoCLR_DataType.DATATYPE_TIMESPAN);
+            s_builtInTypes.Add(typeof(string).FullName, nanoCLR_DataType.DATATYPE_STRING);
+
+            s_builtInTypes.Add("System.RuntimeTypeHandle", nanoCLR_DataType.DATATYPE_REFLECTION);
+            s_builtInTypes.Add("System.RuntimeFieldHandle", nanoCLR_DataType.DATATYPE_REFLECTION);
+            s_builtInTypes.Add("System.RuntimeMethodHandle", nanoCLR_DataType.DATATYPE_REFLECTION);
+
+            s_builtInTypes.Add(typeof(WeakReference).FullName, nanoCLR_DataType.DATATYPE_WEAKCLASS);
         }
 
         /// <summary>
@@ -273,8 +304,9 @@ namespace nanoFramework.Tools.MetadataProcessor
                 return;
             }
 
-            nanoCLR_DataType dataType;
-            if (PrimitiveTypes.TryGetValue(typeDefinition.FullName, out dataType))
+            if (s_primitiveTypes.TryGetValue(
+                typeDefinition.FullName,
+                out nanoCLR_DataType dataType))
             {
                 writer.WriteByte((byte)dataType);
                 return;
@@ -385,6 +417,51 @@ namespace nanoFramework.Tools.MetadataProcessor
             }
 
             writer.WriteByte(0x00);
+        }
+
+        /// <summary>
+        /// Writes data type for type reference.
+        /// </summary>
+        /// <param name="typeDefinition">Type reference or definition in Mono.Cecil format.</param>
+        /// <param name="writer">Target binary writer for writing signature information.</param>
+        public void WriteDataTypeForTypeDef(TypeDefinition typeDefinition, nanoBinaryWriter writer)
+        {
+            // start checking with the built-in types
+            if (s_builtInTypes.TryGetValue(
+                typeDefinition.FullName,
+                out nanoCLR_DataType dataType))
+            {
+                writer.WriteByte((byte)dataType);
+            }
+            else
+            {
+                // check order matters because some types are derived from others
+                if (typeDefinition.IsEnum)
+                {
+                    FieldDefinition baseTypeValue = typeDefinition.Fields.FirstOrDefault(item => item.IsSpecialName);
+
+                    if (baseTypeValue != null)
+                    {
+                        WriteTypeInfo(baseTypeValue.FieldType, writer);
+                    }
+                    else
+                    {
+                        writer.WriteByte((byte)nanoCLR_DataType.DATATYPE_I4);
+                    }
+                }
+                else if (typeDefinition.IsValueType)
+                {
+                    writer.WriteByte((byte)nanoCLR_DataType.DATATYPE_VALUETYPE);
+                }
+                else if (typeDefinition.IsClass || typeDefinition.IsInterface)
+                {
+                    writer.WriteByte((byte)nanoCLR_DataType.DATATYPE_CLASS);
+                }
+                else
+                {
+                    Debug.Fail("Gotcha!");
+                }
+            }
         }
 
         /// <inheritdoc/>
@@ -567,7 +644,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             CustomAttributeArgument argument)
         {
             nanoCLR_DataType dataType;
-            if (PrimitiveTypes.TryGetValue(argument.Type.FullName, out dataType))
+            if (s_primitiveTypes.TryGetValue(argument.Type.FullName, out dataType))
             {
                 switch (dataType)
                 {

--- a/MetadataProcessor.Shared/Tables/nanoTypeDefinitionTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeDefinitionTable.cs
@@ -1,17 +1,16 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// Original work from Oleg Rakhmatulin.
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
 
-using Mono.Cecil;
-using Mono.Collections.Generic;
-using nanoFramework.Tools.MetadataProcessor.Core;
-using nanoFramework.Tools.MetadataProcessor.Core.Extensions;
+// Original work from Oleg Rakhmatulin.
+
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Mono.Cecil;
+using Mono.Collections.Generic;
+using nanoFramework.Tools.MetadataProcessor.Core;
+using nanoFramework.Tools.MetadataProcessor.Core.Extensions;
 
 namespace nanoFramework.Tools.MetadataProcessor
 {
@@ -150,7 +149,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                         writer
                     );
 
-                    _context.SignaturesTable.WriteDataType(item, writer, false, true, true);
+                    _context.SignaturesTable.WriteDataTypeForTypeDef(item, writer);
 
                     writer.WriteBytes(stream.ToArray());
                 }

--- a/MetadataProcessor.Tests/Core/Tables/nanoSignaturesTableTests.cs
+++ b/MetadataProcessor.Tests/Core/Tables/nanoSignaturesTableTests.cs
@@ -1,0 +1,55 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Original work from Oleg Rakhmatulin.
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AssemblyDefinition = Mono.Cecil.AssemblyDefinition;
+using TypeDefinition = Mono.Cecil.TypeDefinition;
+
+namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
+{
+    [TestClass]
+    public class nanoSignaturesTableTests
+    {
+        [DataRow("System.DateTime", nanoCLR_DataType.DATATYPE_DATETIME)]
+        [DataRow("System.TimeSpan", nanoCLR_DataType.DATATYPE_TIMESPAN)]
+        [DataRow("System.String", nanoCLR_DataType.DATATYPE_STRING)]
+        [DataRow("System.Object", nanoCLR_DataType.DATATYPE_CLASS)]
+        [DataRow("System.IntPtr", nanoCLR_DataType.DATATYPE_VALUETYPE)]
+        [DataRow("System.WeakReference", nanoCLR_DataType.DATATYPE_WEAKCLASS)]
+        [TestMethod]
+        public void WriteDataTypeForTypeRef_ShouldWriteCorrectDataType(string typeFullName, nanoCLR_DataType dataType)
+        {
+            // Arrange
+            AssemblyDefinition mscorlibAssemblyDefinition = AssemblyDefinition.ReadAssembly(TestObjectHelper.MscorlibFullPath);
+
+            nanoTablesContext context = new nanoTablesContext(
+                mscorlibAssemblyDefinition,
+                null,
+                new List<string>(),
+                null,
+                false,
+                false,
+                true);
+
+            TypeDefinition typeToTest = mscorlibAssemblyDefinition.MainModule.Types.First(i => i.FullName == typeFullName);
+
+            nanoSignaturesTable table = new nanoSignaturesTable(context);
+            MemoryStream memoryStream = new MemoryStream();
+            BinaryWriter binaryWriter = new BinaryWriter(memoryStream);
+            nanoBinaryWriter writer = nanoBinaryWriter.CreateBigEndianBinaryWriter(binaryWriter);
+
+            // Act
+            table.WriteDataTypeForTypeDef(typeToTest, writer);
+
+            // Assert
+            byte[] expectedBytes = new byte[] { (byte)dataType };
+            byte[] actualBytes = memoryStream.ToArray();
+            CollectionAssert.AreEqual(expectedBytes, actualBytes);
+        }
+    }
+}

--- a/MetadataProcessor.Tests/MetadataProcessor.Tests.csproj
+++ b/MetadataProcessor.Tests/MetadataProcessor.Tests.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Core\Tables\nanoMethodDefinitionTableTests.cs" />
     <Compile Include="Core\Tables\nanoReferenceTableBaseTests.cs" />
     <Compile Include="Core\ClrIntegrationTests.cs" />
+    <Compile Include="Core\Tables\nanoSignaturesTableTests.cs" />
     <Compile Include="Core\Utility\DumperTests.cs" />
     <Compile Include="Core\Utility\LoadHintsAssemblyResolverTests.cs" />
     <Compile Include="Core\Utility\Crc32Tests.cs" />

--- a/MetadataProcessor.Tests/TestObjectHelper.cs
+++ b/MetadataProcessor.Tests/TestObjectHelper.cs
@@ -1,7 +1,7 @@
-﻿//
-// Copyright (c) .NET Foundation and Contributors
-// See LICENSE file in the project root for full license information.
-//
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Original work from Oleg Rakhmatulin.
 
 using System;
 using System.Collections.Generic;
@@ -130,6 +130,16 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests
                 }
 
                 return _testNFClassLibLocation;
+            }
+        }
+
+        public static string MscorlibFullPath
+        {
+            get
+            {
+                return Path.Combine(
+                        TestNFAppLocation,
+                        "mscorlib.dll");
             }
         }
 


### PR DESCRIPTION
## Description
- Add new table with built-in types matching the ones used in nf-interpreter.
- Add new helper method WriteDataTypeForTypeDef.
- Replace call in TyepDef.WriteSingleItem to use new helper method.
- Rename primitive type list to comply with code style.
- Add unit tests for new helper method and type list.
- Add new property with mscorlib path.

## Motivation and Context
- Fixes wrong implementation of TypeDef metadata which wasn't using the built-in types correctly (this was overlooked when porting the code from the original C++ tool from .NETMF).

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Adding new unit tests.
- Generated metadata cross checked with old C++ MDP version.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
