### PR TITLE
Add processing of exclude type attribute

### DIFF
--- a/MetadataProcessor.Console/Program.cs
+++ b/MetadataProcessor.Console/Program.cs
@@ -17,7 +17,7 @@ using System.Xml;
 namespace nanoFramework.Tools.MetadataProcessor.Console
 {
     internal static class MainClass
-	{
+    {
         private sealed class MetadataProcessor
         {
             private readonly IDictionary<string, string> _loadHints =
@@ -40,10 +40,10 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
             {
                 try
                 {
-                    if(Verbose) System.Console.WriteLine("Parsing assembly...");
+                    if (Verbose) System.Console.WriteLine("Parsing assembly...");
 
                     _assemblyDefinition = AssemblyDefinition.ReadAssembly(fileName,
-                        new ReaderParameters { AssemblyResolver = new LoadHintsAssemblyResolver(_loadHints)});
+                        new ReaderParameters { AssemblyResolver = new LoadHintsAssemblyResolver(_loadHints) });
                 }
                 catch (Exception)
                 {
@@ -98,7 +98,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                         _assemblyBuilder.Write(writer);
                     }
 
-                    if(DumpMetadata)
+                    if (DumpMetadata)
                     {
                         nanoDumperGenerator dumper = new nanoDumperGenerator(
                             _assemblyBuilder.TablesContext,
@@ -187,7 +187,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
         }
 
         public static void Main(string[] args)
-		{
+        {
             FileVersionInfo fileVersion = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
 
             bool isCoreLibrary = false;
@@ -206,9 +206,9 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
             {
                 var arg = args[i].ToLower(CultureInfo.InvariantCulture);
 
-                if ( (arg == "-h" ||
+                if ((arg == "-h" ||
                     arg == "-help" ||
-                    arg == "?") && 
+                    arg == "?") &&
                     (i + 1 < args.Length))
                 {
                     System.Console.WriteLine("");
@@ -244,6 +244,10 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                 }
                 else if (arg == "-excludeclassbyname" && i + 1 < args.Length)
                 {
+                    System.Console.WriteLine("*********************************************** WARNING *************************************************");
+                    System.Console.WriteLine("Use ExcludeTypeAttribute instead of passing this option. This will be removed in a future version of MDP.");
+                    System.Console.WriteLine("*********************************************************************************************************");
+
                     md.AddClassToExclude(args[++i]);
                 }
                 else if (arg == "-verbose")
@@ -296,6 +300,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                     System.Console.Error.WriteLine("Unknown command line option '{0}' ignored.", arg);
                 }
             }
-		}
+        }
     }
 }

--- a/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
+++ b/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
@@ -37,6 +37,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
 
         public string LoadStrings { get; set; }
 
+        [Obsolete("Use ExcludeTypeAttribute instead of passing this parameter. This will be removed in a future version of MDP.")]
         public ITaskItem[] ExcludeClassByName { get; set; }
 
         public ITaskItem[] ImportResources { get; set; }
@@ -154,13 +155,16 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                 if (ExcludeClassByName != null &&
                     ExcludeClassByName.Any())
                 {
-                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Processing class exclusion list..");
+                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Processing class exclusion list.");
 
-                    foreach (var className in ExcludeClassByName)
+                    foreach (ITaskItem className in ExcludeClassByName)
                     {
                         _classNamesToExclude.Add(className.ToString());
 
-                        if (Verbose) Log.LogCommandLine(MessageImportance.Normal, $"Adding '{className.ToString()}' to collection of classes to exclude");
+                        if (Verbose)
+                        {
+                            Log.LogCommandLine(MessageImportance.Normal, $"Adding '{className.ToString()}' to collection of classes to exclude");
+                        }
                     }
                 }
 

--- a/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
@@ -4,10 +4,10 @@
 // See LICENSE file in the project root for full license information.
 //
 
-using Mono.Cecil;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Mono.Cecil;
 
 namespace nanoFramework.Tools.MetadataProcessor
 {
@@ -24,18 +24,21 @@ namespace nanoFramework.Tools.MetadataProcessor
                 "System.Runtime.InteropServices.GuidAttribute",
 
                 // Compiler-specific attributes
-                //"System.ParamArrayAttribute",
-                //"System.SerializableAttribute",
-                //"System.NonSerializedAttribute",
-                //"System.Runtime.InteropServices.StructLayoutAttribute",
-                //"System.Runtime.InteropServices.LayoutKind",
-                //"System.Runtime.InteropServices.OutAttribute",
-                //"System.Runtime.CompilerServices.ExtensionAttribute",
-                //"System.Runtime.CompilerServices.MethodImplAttribute",
-                //"System.Runtime.CompilerServices.InternalsVisibleToAttribute",
-                //"System.Runtime.CompilerServices.IndexerNameAttribute",
-                //"System.Runtime.CompilerServices.MethodImplOptions",
-                //"System.Reflection.FieldNoReflectionAttribute",
+                "System.ParamArrayAttribute",
+                "System.SerializableAttribute",
+                "System.NonSerializedAttribute",
+                "System.Runtime.InteropServices.StructLayoutAttribute",
+                "System.Runtime.InteropServices.LayoutKind",
+                "System.Runtime.InteropServices.OutAttribute",
+                "System.Runtime.CompilerServices.ExtensionAttribute",
+                "System.Runtime.CompilerServices.MethodImplAttribute",
+                "System.Runtime.CompilerServices.NullableAttribute",
+                "System.Runtime.CompilerServices.NullableContextAttribute",
+                "System.Runtime.CompilerServices.InternalsVisibleToAttribute",
+                "System.Runtime.CompilerServices.IndexerNameAttribute",
+                "System.Runtime.CompilerServices.MethodImplOptions",
+                "System.Runtime.CompilerServices.RefSafetyRulesAttribute",
+                "System.Reflection.FieldNoReflectionAttribute",
 
                 // Debugger-specific attributes
                 "System.Diagnostics.DebuggableAttribute",
@@ -56,7 +59,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                 // Intellisense filtering attributes
                 "System.ComponentModel.EditorBrowsableAttribute",
 
-                //Not supported
+                // Not supported
                 "System.Reflection.DefaultMemberAttribute",
 
                 // Not supported attributes
@@ -79,8 +82,11 @@ namespace nanoFramework.Tools.MetadataProcessor
             _verbose = verbose;
             _isCoreLibrary = isCoreLibrary;
 
+            // add default types to exclude
+            SetDefaultTypesToExclude();
+
             // check CustomAttributes against list of classes to exclude
-            foreach (var item in assemblyDefinition.CustomAttributes)
+            foreach (CustomAttribute item in assemblyDefinition.CustomAttributes)
             {
                 // add it to ignore list, if it's not already there
                 if ((ClassNamesToExclude.Contains(item.AttributeType.FullName) ||
@@ -93,7 +99,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             }
 
             // check ignoring attributes against ClassNamesToExclude 
-            foreach (var className in ClassNamesToExclude)
+            foreach (string className in ClassNamesToExclude)
             {
                 if (!IgnoringAttributes.Contains(className))
                 {
@@ -133,9 +139,12 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             // Internal types definitions
 
-            var types = GetOrderedTypes(mainModule, explicitTypesOrder);
+            List<TypeDefinition> types = GetOrderedTypes(mainModule, explicitTypesOrder);
 
             TypeDefinitionTable = new nanoTypeDefinitionTable(types, this);
+
+            // get types to exclude from the types attributes
+            ProcessTypesToExclude(types);
 
             var fields = types
                 .SelectMany(item => GetOrderedFields(item.Fields.Where(field => !field.HasConstant)))
@@ -459,5 +468,29 @@ namespace nanoFramework.Tools.MetadataProcessor
             ResourceDataTable = new nanoResourceDataTable();
             ResourceFileTable = new nanoResourceFileTable(this);
         }
+
+        private static void ProcessTypesToExclude(List<TypeDefinition> types)
+        {
+            // loop through all types and find out which ones have the ExcludeTypeAttribute, so they are added to the exclusion lis
+            foreach (TypeDefinition type in types)
+            {
+                if (type.HasCustomAttributes)
+                {
+                    CustomAttribute excludeTypeAttribute = type.CustomAttributes.FirstOrDefault(ca => ca.AttributeType.FullName == "System.Runtime.CompilerServices.ExcludeTypeAttribute");
+                    if (excludeTypeAttribute != null)
+                    {
+                        ClassNamesToExclude.Add(type.FullName);
+                    }
+                }
+            }
+        }
+
+        private void SetDefaultTypesToExclude()
+        {
+            ClassNamesToExclude.Add("ThisAssembly");
+            ClassNamesToExclude.Add("System.Runtime.CompilerServices.RefSafetyRulesAttribute");
+            ClassNamesToExclude.Add("System.Runtime.CompilerServices.AccessedThroughPropertyAttribute");
+        }
+
     }
 }

--- a/MetadataProcessor.Shared/nanoDumperGenerator.cs
+++ b/MetadataProcessor.Shared/nanoDumperGenerator.cs
@@ -91,9 +91,10 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                             TypeToken = fa.CustomAttributes[0].Constructor.MetadataToken.ToInt32().ToString("x8")
                         };
 
-                        if (fa.CustomAttributes[0].HasConstructorArguments)
+                        if (!nanoTablesContext.IgnoringAttributes.Contains(fa.CustomAttributes[0].AttributeType.FullName)
+                            && fa.CustomAttributes[0].HasConstructorArguments)
                         {
-                            foreach (var value in fa.CustomAttributes[0].ConstructorArguments)
+                            foreach (CustomAttributeArgument value in fa.CustomAttributes[0].ConstructorArguments)
                             {
                                 attribute.FixedArgs.AddRange(BuildFixedArgsAttribute(value));
                             }

--- a/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
+++ b/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
@@ -1,4 +1,4 @@
-//
+﻿//
 // Copyright (c) .NET Foundation and Contributors
 // See LICENSE file in the project root for full license information.
 //
@@ -90,7 +90,8 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
             foreach (var c in _tablesContext.TypeDefinitionTable.TypeDefinitions)
             {
                 if (c.IncludeInStub() &&
-                    !c.IsToExclude())
+                    !c.IsToExclude() &&
+                    !nanoTablesContext.IgnoringAttributes.Contains(c.FullName))
                 {
                     var className = NativeMethodsCrc.GetClassName(c);
 

--- a/MetadataProcessor.Tests/Core/ClrIntegrationTests.cs
+++ b/MetadataProcessor.Tests/Core/ClrIntegrationTests.cs
@@ -330,10 +330,10 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core
         {
             StringBuilder arguments = new StringBuilder(" --localinstance");
 
-//#if DEBUG
-//            arguments.Append($" \"{_localClrInstancePath}\"");
+#if DEBUG
+            arguments.Append($" \"{_localClrInstancePath}\"");
 
-//#else
+#else
             if (string.IsNullOrEmpty(TestObjectHelper.NanoClrLocalInstance))
             {
                 return null;
@@ -342,7 +342,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core
             {
                 arguments.Append($" \"{TestObjectHelper.NanoClrLocalInstance}\"");
             }
-//#endif
+#endif
 
             return arguments.ToString();
         }

--- a/MetadataProcessor.Tests/Core/Extensions/TypeDefinitionExtensionsTests.cs
+++ b/MetadataProcessor.Tests/Core/Extensions/TypeDefinitionExtensionsTests.cs
@@ -7,6 +7,9 @@ using System;
 using System.Linq;
 using nanoFramework.Tools.MetadataProcessor.Core.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mono.Cecil;
+using System.IO;
+using System.Collections.Generic;
 
 namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Extensions
 {
@@ -58,7 +61,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Extensions
         public void IsClassToExcludeTest()
         {
             var nanoTablesContext = TestObjectHelper.GetTestNFAppNanoTablesContext();
-            Assert.IsFalse(nanoTablesContext.ClassNamesToExclude.Any());
 
             var oneClassOverAllTypeDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllTypeDefinition(nanoTablesContext.AssemblyDefinition);
             var oneClassOverAllSubClassTypeDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllSubClassTypeDefinition(nanoTablesContext.AssemblyDefinition);
@@ -91,6 +93,82 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Extensions
             r = oneClassOverAllSubClassTypeDefinition.IsToExclude();
 
             Assert.IsTrue(r);
+        }
+
+        [TestMethod]
+        public void TypesInLibraryToExcludeTests()
+        {
+            // Arrange
+            string libLocation = Path.Combine(
+                TestObjectHelper.TestExecutionLocation,
+                "TestNFClassLibrary");
+
+            string libAssemblyLocation = Path.Combine(
+                libLocation,
+               "TestNFClassLibrary.dll");
+
+            AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(libAssemblyLocation);
+
+            nanoTablesContext nanoTablesContext = new nanoTablesContext(
+                assemblyDefinition,
+                null,
+                // adding this here, equivalent to the NFMDP_PE_ExcludeClassByName project property
+                new List<string>() { "TestNFClassLibrary.IAmATypeToExclude" },
+                null,
+                false,
+                false,
+                false);
+
+            ModuleDefinition testNFLibraryModule = nanoTablesContext.AssemblyDefinition.Modules[0];
+
+            // Assert
+
+            // test if <TestNFClassLibrary.ClassOnAnotherAssembly> type is present
+            Assert.IsNotNull(testNFLibraryModule.Types.FirstOrDefault(i => i.FullName == "TestNFClassLibrary.ClassOnAnotherAssembly"), "TestNFClassLibrary.ClassOnAnotherAssembly type not found");
+
+            // test if <TestNFClassLibrary.IAmATypeToExclude> type is present
+            Assert.IsNotNull(testNFLibraryModule.Types.FirstOrDefault(i => i.FullName == "TestNFClassLibrary.IAmATypeToExclude"), "TestNFClassLibrary.IAmATypeToExclude type not found");
+
+            // test if <TestNFClassLibrary.IAmATypeToExclude> type is to be excluded
+            // this is being excluded with the NFMDP_PE_ExcludeClassByName project property
+            Assert.IsTrue(testNFLibraryModule.Types.First(i => i.FullName == "TestNFClassLibrary.IAmATypeToExclude").IsToExclude(), "TestNFClassLibrary.IAmATypeToExclude type is not listed to be excluded, when it should");
+
+            // test if <TestNFClassLibrary.IAmAlsoATypeToExclude> type is present
+            Assert.IsNotNull(testNFLibraryModule.Types.FirstOrDefault(i => i.FullName == "TestNFClassLibrary.IAmAlsoATypeToExclude"), "TestNFClassLibrary.IAmAlsoATypeToExclude type not found");
+
+            // test if <TestNFClassLibrary.IAmAlsoATypeToExclude> type is to be excluded
+            // this is being excluded with the ExcludeType attribute
+            Assert.IsTrue(testNFLibraryModule.Types.First(i => i.FullName == "TestNFClassLibrary.IAmAlsoATypeToExclude").IsToExclude(), "TestNFClassLibrary.IAmAlsoATypeToExclude type is not listed to be excluded, when it should");
+
+            // test if <TestNFClassLibrary.IAmAnEnumToExclude> type is present
+            Assert.IsNotNull(testNFLibraryModule.Types.FirstOrDefault(i => i.FullName == "TestNFClassLibrary.IAmAnEnumToExclude"), "TestNFClassLibrary.IAmAnEnumToExclude type not found");
+
+            // test if <TestNFClassLibrary.IAmAnEnumToExclude> type is to be excluded
+            // this is being excluded with the ExcludeType attribute
+            Assert.IsTrue(testNFLibraryModule.Types.First(i => i.FullName == "TestNFClassLibrary.IAmAnEnumToExclude").IsToExclude(), "TestNFClassLibrary.IAmAnEnumToExclude type is not listed to be excluded, when it should");
+        }
+
+        [TestMethod]
+        public void DefaultTypesToExcludeTests()
+        {
+            // Arrange
+            AssemblyDefinition mscorlibAssemblyDefinition = AssemblyDefinition.ReadAssembly(TestObjectHelper.MscorlibFullPath);
+
+            nanoTablesContext context = new nanoTablesContext(
+                mscorlibAssemblyDefinition,
+                null,
+                new List<string>(),
+                null,
+                false,
+                false,
+                true);
+
+            ModuleDefinition mscorlibModule = context.AssemblyDefinition.Modules[0];
+
+            // Assert
+            Assert.IsNotNull(context);
+
+            Assert.IsTrue(mscorlibModule.Types.First(i => i.FullName == "ThisAssembly").IsToExclude(), "ThisAssembly type is not listed to be excluded, when it should");
         }
     }
 }

--- a/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmATypeToExclude.cs
+++ b/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmATypeToExclude.cs
@@ -1,0 +1,12 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+namespace TestNFClassLibrary
+{
+    // this type does nothing, its here to test the backwards compatibility with NFMDP_PE_ExcludeClassByName project property to exclude types
+    public class IAmATypeToExclude
+    {
+    }
+}

--- a/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmAlsoATypeToExclude.cs
+++ b/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmAlsoATypeToExclude.cs
@@ -1,0 +1,15 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+
+namespace TestNFClassLibrary
+{
+    // this type does nothing, its here to test the ExcludeType attribute
+    [ExcludeType]
+    public class IAmAlsoATypeToExclude
+    {
+    }
+}

--- a/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmAnEnumToExclude.cs
+++ b/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmAnEnumToExclude.cs
@@ -1,0 +1,18 @@
+﻿//
+// Copyright (c) .NET Foundation and Contributors
+// See LICENSE file in the project root for full license information.
+//
+
+using System.Runtime.CompilerServices;
+
+namespace TestNFClassLibrary
+{
+    // this type does nothing, its here to test the ExcludeType attribute
+    [ExcludeType]
+    public enum IAmAnEnumToExclude
+    {
+        None = 0,
+        Test = 1,
+        Test2 = 2
+    }
+}

--- a/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/TestNFClassLibrary.nfproj
+++ b/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/TestNFClassLibrary.nfproj
@@ -20,7 +20,15 @@
   <ItemGroup>
     <Compile Include="IAmAClassWithAnEnum.cs" />
     <Compile Include="ClassOnAnotherAssembly.cs" />
+    <Compile Include="IAmAnEnumToExclude.cs" />
+    <Compile Include="IAmAlsoATypeToExclude.cs" />
+    <Compile Include="IAmATypeToExclude.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <NFMDP_PE_ExcludeClassByName Include="TestNFClassLibrary.IAmATypeToExclude">
+      <InProject>false</InProject>
+    </NFMDP_PE_ExcludeClassByName>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\mscorlib\nanoFramework.CoreLibrary\CoreLibrary.nfproj" />

--- a/MetadataProcessor.Tests/TestObjectHelper.cs
+++ b/MetadataProcessor.Tests/TestObjectHelper.cs
@@ -43,6 +43,20 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests
             return ret;
         }
 
+        public static nanoTablesContext GetTestNFLibraryTablesContext()
+        {
+            AssemblyDefinition assemblyDefinition = AssemblyDefinition.ReadAssembly(TestNFClassLibFullPath);
+
+            return new nanoTablesContext(
+                assemblyDefinition,
+                null,
+                new List<string>(),
+                null,
+                false,
+                false,
+                false);
+        }
+
         public static string Configuration => _configuration;
 
         public static string TestExecutionLocation


### PR DESCRIPTION
## Description
- nanoTablesContext constructor now creates a default list of types to ignore.
- nanoTablesContext constructor now processes type to exclude by checking the custom attributes looking for ExcludeTypeAttribute.
- Dumper generator now checks for attributes to ignore.
- Skeleton generator now checks for attributes to ignore when generating class declarations.
- Uncomment several attribute types that are to be ignored by MDP.
- Minor code style improvements.
- Add test classes with the ExcludeType attributes to NF class test library.
- Add unit tests to cover all these changes.
- Add obsolete attribute to ExcludeClassByName.
- Add warning to MDP console.

## Motivation and Context
- Use new attribute ExcludeTypeAttribute.
- Simplify nfproj file by removing the list of types to exclude.
- Stop adding unused/unnecessary types to assemblies, dump output and stubs.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP Unit tests and mscorlib unit tests using a local virtual device with the updated assembly declaration.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
