### PR TITLE
Fix handling of TypeSpec fields

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
@@ -130,6 +130,21 @@ namespace nanoFramework.Tools.MetadataProcessor
             return _idByTypeSpecifications.FirstOrDefault(typeEntry => typeEntry.Key.MetadataToken == token).Key;
         }
 
+        /// <summary>
+        /// Tries to find type reference by the index on the TypeSpec list.
+        /// </summary>
+        /// <param name="index">Index of the type reference in the list.</param>
+        /// <returns>Returns the type reference if found, otherwise returns <c>null</c>.</returns>
+        public TypeReference TryGetTypeReferenceByIndex(ushort index)
+        {
+            if (index >= _idByTypeSpecifications.Count)
+            {
+                return null;
+            }
+
+            return _idByTypeSpecifications.ElementAt(index).Key;
+        }
+
         /// <inheritdoc/>
         public void Write(
             nanoBinaryWriter writer)

--- a/MetadataProcessor.Shared/nanoDumperGenerator.cs
+++ b/MetadataProcessor.Shared/nanoDumperGenerator.cs
@@ -734,6 +734,25 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     }
                 }
 
+                foreach (var fr in _tablesContext.FieldReferencesTable.Items)
+                {
+                    if (_tablesContext.TypeSpecificationsTable.TryGetTypeReferenceId(fr.DeclaringType, out ushort referenceId) &&
+                        referenceId == index)
+                    {
+                        var memberRef = new MemberRef()
+                        {
+                            Name = fr.Name
+                        };
+                        if (_tablesContext.FieldReferencesTable.TryGetFieldReferenceId(fr, out ushort fieldRefId))
+                        {
+                            realToken = fr.MetadataToken.ToInt32().ToString("X8");
+                            memberRef.ReferenceId = $"[{new nanoMetadataToken(NanoClrTable.TBL_FieldRef, fieldRefId)}] /*{realToken}*/";
+                            memberRef.Signature = fr.FieldType.TypeSignatureAsString();
+                        }
+                        typeSpec.MemberReferences.Add(memberRef);
+                    }
+                }
+
                 Debug.Assert(typeSpec.MemberReferences.Count > 0, $"Couldn't find any MethodRef for TypeSpec[{typeReference}] {typeReference.FullName}");
             }
 

--- a/MetadataProcessor.Tests/Core/Utility/DumperTests.cs
+++ b/MetadataProcessor.Tests/Core/Utility/DumperTests.cs
@@ -133,7 +133,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             nanoTablesContext.TypeReferencesTable.TryGetTypeReferenceId(type1.BaseType, out baseTypeReferenceId);
             typeFlags = (uint)nanoTypeDefinitionTable.GetFlags(type1, nanoTablesContext.MethodDefinitionTable);
 
-            Assert.IsTrue(dumpFileContent.Contains($"TypeDef {nanoDumperGenerator.TypeDefRefIdToString(type1, typeRefId)}\r\n-------------------------------------------------------\r\n    '{type1.Name}'\r\n    Flags: {typeFlags:X8}\r\n    Extends: {nanoDumperGenerator.TypeDefExtendsTypeToString(type1.BaseType, baseTypeReferenceId)}\r\n    Enclosed: TestNFApp.OneClassOverAll[04000000] /*0200001B*/"));
+            Assert.IsTrue(dumpFileContent.Contains($"TypeDef {nanoDumperGenerator.TypeDefRefIdToString(type1, typeRefId)}\r\n-------------------------------------------------------\r\n    '{type1.Name}'\r\n    Flags: {typeFlags:X8}\r\n    Extends: {nanoDumperGenerator.TypeDefExtendsTypeToString(type1.BaseType, baseTypeReferenceId)}\r\n    Enclosed: TestNFApp.OneClassOverAll[04000000] /*0200001D*/"));
 
             // String heap
             foreach (string stringKey in nanoTablesContext.StringTable.GetItems().Keys)

--- a/MetadataProcessor.Tests/TestNFApp/Program.cs
+++ b/MetadataProcessor.Tests/TestNFApp/Program.cs
@@ -80,6 +80,7 @@ namespace TestNFApp
             ///////////////////////////////////////////////////////////////////
             // Generics Tests
             _ = new GenericClassTests();
+            _ = new StatckTests();
 
             // null attributes tests
             Console.WriteLine("Null attributes tests");

--- a/MetadataProcessor.Tests/TestNFApp/StackClass.cs
+++ b/MetadataProcessor.Tests/TestNFApp/StackClass.cs
@@ -1,0 +1,43 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace TestNFApp
+{
+    public class Stack<T>
+    {
+        private readonly T[] _items;
+        private int _count;
+
+        public Stack(int size) => _items = new T[size];
+
+        public void Push(T item) => _items[_count++] = item;
+
+        public T Pop() => _items[--_count];
+    }
+
+    public class StatckTests
+    {
+        public StatckTests()
+        {
+            // Create a stack of integers
+            Stack<int> intStack = new Stack<int>(5);
+
+            intStack.Push(1);
+            intStack.Push(2);
+
+            Console.WriteLine($"First value is{intStack.Pop()}");
+            Console.WriteLine($"Second value is{intStack.Pop()}");
+
+            // Create a stack of strings
+            Stack<string> stringStack = new Stack<string>(5);
+
+            stringStack.Push("Hello");
+            stringStack.Push("World");
+
+            Console.WriteLine($"First value is {stringStack.Pop()}");
+            Console.WriteLine($"Second value is {stringStack.Pop()}");
+        }
+    }
+}

--- a/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
+++ b/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
@@ -23,6 +23,7 @@
     <Compile Include="DataRowAttribute.cs" />
     <Compile Include="DummyCustomAttribute1.cs" />
     <Compile Include="DummyCustomAttribute2.cs" />
+    <Compile Include="StackClass.cs" />
     <Compile Include="IgnoreAttribute.cs" />
     <Compile Include="IOneClassOverAll.cs" />
     <Compile Include="ComplexAttribute.cs" />


### PR DESCRIPTION
## Description
- GetFieldReferenceId can deal with member references.
- Improve handling of TypeSpecs in BuildDependencyList, now it processes the real and fabricated tokens during minimization.
- Add more developer notes to explain reasoning and overall functioning for TypeSpecs.
- Dumper generator now outputs field references properly.
- Add Stack class to test applications.

## Motivation and Context
- Fixes handling of TypeSpec fields.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit test and using test app in the solution with new classes.
[tested against nanoclr buildId 55800]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
