### PR TITLE
Improve crawling of member refs and generics instances to fill TypeSpec table

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
@@ -100,8 +100,8 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             _idByTypeSpecifications = new Dictionary<TypeReference, ushort>(new TypeReferenceEqualityComparer(context));
 
+            AddTypeLevelGenericParameters();
             FillTypeSpecsFromTypes();
-
             FillTypeSpecsFromMemberReferences();
         }
 
@@ -124,14 +124,52 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             return false;
         }
-
         public TypeReference TryGetTypeSpecification(MetadataToken token)
         {
-            return _idByTypeSpecifications.FirstOrDefault(typeEntry => typeEntry.Key.MetadataToken == token).Key;
+            // try a direct match on the TypeReference itself
+            TypeReference direct = _idByTypeSpecifications.Keys.FirstOrDefault(t => t.MetadataToken == token);
+
+            if (direct != null)
+            {
+                return direct;
+            }
+
+            // Look among the generic-instances already seeded
+            GenericInstanceType genericInst = _idByTypeSpecifications.Keys
+                .OfType<GenericInstanceType>()
+                .FirstOrDefault(git => git.ElementType.MetadataToken == token);
+
+            if (genericInst != null)
+            {
+                return genericInst;
+            }
+
+            // maybe this instanced type is in TypeReferencesTable
+            GenericInstanceType external = _context.TypeReferencesTable.Items
+                .OfType<GenericInstanceType>()
+                .FirstOrDefault(git => git.ElementType.MetadataToken == token);
+
+            if (external != null)
+            {
+                // seed it now so future lookups find it immediately
+                ushort sigId = _context.SignaturesTable.GetOrCreateSignatureId(external);
+
+                AddIfNew(external, sigId);
+
+                // and pull in its nested specs (generic arguments, element types, etc.)
+                ExpandNestedTypeSpecs(external);
+
+                return external;
+            }
+
+            // some edge case not being handled...
+            // default to null
+            return null;
         }
 
+
         /// <summary>
-        /// Tries to find type reference by the index on the TypeSpec list.
+        /// Tries to find type reference by the index on the <see cref="TypeSpec"/> list.
         /// </summary>
         /// <param name="index">Index of the type reference in the list.</param>
         /// <returns>Returns the type reference if found, otherwise returns <c>null</c>.</returns>
@@ -197,43 +235,161 @@ namespace nanoFramework.Tools.MetadataProcessor
                     }
                 }
             }
+
+            // make sure we pick up *all* GenericInstanceType entries
+            // that may have come in via the TypeReferencesTable.
+            foreach (GenericInstanceType genericInstanceType in _context.TypeReferencesTable.Items.OfType<GenericInstanceType>())
+            {
+                if (!_idByTypeSpecifications.ContainsKey(genericInstanceType))
+                {
+                    // create or get the signature ID for this instanced type
+                    ushort sigId = _context.SignaturesTable.GetOrCreateSignatureId(genericInstanceType);
+                    _idByTypeSpecifications.Add(genericInstanceType, sigId);
+
+                    // (and don’t forget to pull in any nested generic-parameter args)
+                    foreach (GenericParameter arg in genericInstanceType.GenericArguments.OfType<GenericParameter>())
+                    {
+                        if (!_idByTypeSpecifications.ContainsKey(arg))
+                        {
+                            ushort argSig = _context.SignaturesTable.GetOrCreateSignatureId(arg);
+                            _idByTypeSpecifications.Add(arg, argSig);
+                        }
+                    }
+                }
+            }
         }
 
         private void FillTypeSpecsFromTypes()
         {
-            foreach (TypeDefinition t in _context.TypeDefinitionTable.Items)
+            foreach (TypeDefinition td in _context.TypeDefinitionTable.Items)
             {
-                foreach (MethodDefinition m in t.Methods.Where(method => method.HasBody))
+                foreach (MethodDefinition m in td.Methods.Where(m => m.HasBody))
                 {
-                    foreach (Instruction instruction in m.Body.Instructions)
+                    foreach (Instruction instr in m.Body.Instructions)
                     {
-                        if (instruction.Operand is GenericParameter genericParameter)
+                        if (instr.Operand is GenericParameter gp)
                         {
-                            ushort signatureId = _context.SignaturesTable.GetOrCreateSignatureId(genericParameter);
-
-                            if (!_idByTypeSpecifications.ContainsKey(genericParameter))
-                            {
-                                _idByTypeSpecifications.Add(genericParameter, signatureId);
-                            }
+                            AddIfNew(gp, _context.SignaturesTable.GetOrCreateSignatureId(gp));
                         }
-                        else if (instruction.Operand is TypeReference typeReference)
+                        else if (instr.Operand is TypeReference tr)
                         {
-                            // Optional: Check additional conditions if needed,
-                            // for example, if the operand type should be an array.
-                            if (instruction.OpCode.OperandType == OperandType.InlineType && !typeReference.IsArray)
+                            // refuse multi-dimensional arrays
+                            // we only support jagged arrays
+                            if (tr.IsArray)
                             {
-                                continue;
+                                var at = (ArrayType)tr;
+
+                                if (at.Rank > 1)
+                                {
+                                    throw new ArgumentException(
+                                        $".NET nanoFramework only supports jagged arrays: {tr.FullName}");
+                                }
                             }
 
-                            ushort signatureId = _context.SignaturesTable.GetOrCreateSignatureId(typeReference);
+                            // register the type reference itself...
+                            ushort sigId = _context.SignaturesTable.GetOrCreateSignatureId(tr);
+                            AddIfNew(tr, sigId);
 
-                            if (!_idByTypeSpecifications.ContainsKey(typeReference))
-                            {
-                                _idByTypeSpecifications.Add(typeReference, signatureId);
-                            }
+                            // ... then walk *into* any nested TypeSpecifications it might contain
+                            ExpandNestedTypeSpecs(tr);
                         }
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Recursively finds any TypeSpecification bits of 't' and adds them
+        /// (element types, generic arguments, declaring types, by/ref, pointers, etc.)
+        /// </summary>
+        private void ExpandNestedTypeSpecs(TypeReference t)
+        {
+            if (!(t is TypeSpecification ts))
+            {
+                return;
+            }
+
+            // element type of pointers, by-refs, modifiers, arrays, & generic definitions
+            TypeReference inner = null;
+            switch (ts)
+            {
+                case GenericInstanceType git:
+                    inner = git.ElementType;
+                    foreach (var arg in git.GenericArguments)
+                        ExpandNestedTypeSpecs(arg);
+                    break;
+
+                case ArrayType at:
+                    inner = at.ElementType;
+                    break;
+
+                case ByReferenceType br:
+                    inner = br.ElementType;
+                    break;
+
+                case PointerType pt:
+                    inner = pt.ElementType;
+                    break;
+
+                case OptionalModifierType om:
+                    inner = om.ElementType;
+                    break;
+
+                case RequiredModifierType rm:
+                    inner = rm.ElementType;
+                    break;
+            }
+
+            if (inner != null)
+            {
+                ushort innerId = _context.SignaturesTable.GetOrCreateSignatureId(inner);
+                AddIfNew(inner, innerId);
+                ExpandNestedTypeSpecs(inner);
+            }
+
+            // nested/declaring types
+            if (ts.DeclaringType != null)
+            {
+                TypeReference decl = ts.DeclaringType;
+                ushort declId = _context.SignaturesTable.GetOrCreateSignatureId(decl);
+                AddIfNew(decl, declId);
+                ExpandNestedTypeSpecs(decl);
+            }
+        }
+
+        /// <summary>
+        /// Helper to add to `_idByTypeSpecifications` only if we haven’t already seen it
+        /// </summary>
+        private void AddIfNew(
+            TypeReference tr,
+            ushort sigId)
+        {
+            if (!_idByTypeSpecifications.ContainsKey(tr))
+            {
+                _idByTypeSpecifications.Add(tr, sigId);
+            }
+        }
+
+        private void AddTypeLevelGenericParameters()
+        {
+            foreach (TypeDefinition td in _context.TypeDefinitionTable.Items.Where(t => t.HasGenericParameters))
+            {
+                // register each generic parameter (T)
+                foreach (GenericParameter gp in td.GenericParameters)
+                {
+                    ushort gpSig = _context.SignaturesTable.GetOrCreateSignatureId(gp);
+                    AddIfNew(gp, gpSig);
+                }
+
+                // seed the *open* GenericInstanceType (e.g. Action`1<T>)
+                var openGeneric = new GenericInstanceType(td);
+                foreach (GenericParameter gp in td.GenericParameters)
+                {
+                    openGeneric.GenericArguments.Add(gp);
+                }
+
+                ushort openSig = _context.SignaturesTable.GetOrCreateSignatureId(openGeneric);
+                AddIfNew(openGeneric, openSig);
             }
         }
     }


### PR DESCRIPTION
## Description
- Add new edge cases.
- Add new helper methods.
- Minor code style improvements.

## Motivation and Context
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests in MDP.
- Parsing mscorlib implementing Span<>().
[tested against nanoclr buildId 55854]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
