### PR TITLE
Fix WriteDataType for generic types and arrays

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Original work from Oleg Rakhmatulin.
@@ -433,20 +433,22 @@ namespace nanoFramework.Tools.MetadataProcessor
             {
                 writer.WriteByte((byte)NanoCLRDataType.DATATYPE_SZARRAY);
 
-                var array = (ArrayType)typeDefinition;
-
-                if (array.ElementType.IsGenericParameter)
+                if (alsoWriteSubType)
                 {
-                    // ECMA 335 VI.B.4.3 Metadata
-                    writer.WriteByte((byte)NanoCLRDataType.DATATYPE_VAR);
+                    ArrayType array = (ArrayType)typeDefinition;
 
-                    // OK to use byte here as we won't support more than 0x7F generic parameters
-                    writer.WriteByte((byte)(array.ElementType as GenericParameter).Position);
-                }
-                else if (alsoWriteSubType)
-                {
+                    if (array.ElementType.IsGenericParameter)
+                    {
+                        // ECMA 335 VI.B.4.3 Metadata
+                        writer.WriteByte((byte)NanoCLRDataType.DATATYPE_VAR);
 
-                    WriteDataType(array.ElementType, writer, true, expandEnumType, isTypeDefinition);
+                        // OK to use byte here as we won't support more than 0x7F generic parameters
+                        writer.WriteByte((byte)(array.ElementType as GenericParameter).Position);
+                    }
+                    else
+                    {
+                        WriteDataType(array.ElementType, writer, true, expandEnumType, isTypeDefinition);
+                    }
                 }
 
                 return;
@@ -458,7 +460,7 @@ namespace nanoFramework.Tools.MetadataProcessor
 
                 if (alsoWriteSubType)
                 {
-                    var resolvedType = typeDefinition.Resolve();
+                    TypeDefinition resolvedType = typeDefinition.Resolve();
 
                     WriteDataType(resolvedType, writer, false, expandEnumType, isTypeDefinition);
                 }
@@ -472,15 +474,18 @@ namespace nanoFramework.Tools.MetadataProcessor
                 // II.23.2.12 Type
                 writer.WriteByte((byte)NanoCLRDataType.DATATYPE_GENERICINST);
 
-                var genericType = (GenericInstanceType)typeDefinition;
-                WriteDataType(genericType.Resolve(), writer, true, expandEnumType, isTypeDefinition);
-
-                // OK to use byte here as we won't support more than 0x7F arguments
-                writer.WriteByte((byte)genericType.GenericArguments.Count);
-
-                foreach (var a in genericType.GenericArguments)
+                if (alsoWriteSubType)
                 {
-                    WriteDataType(a, writer, true, expandEnumType, isTypeDefinition);
+                    GenericInstanceType genericType = (GenericInstanceType)typeDefinition;
+                    WriteDataType(genericType.Resolve(), writer, true, expandEnumType, isTypeDefinition);
+
+                    // OK to use byte here as we won't support more than 0x7F arguments
+                    writer.WriteByte((byte)genericType.GenericArguments.Count);
+
+                    foreach (TypeReference a in genericType.GenericArguments)
+                    {
+                        WriteDataType(a, writer, true, expandEnumType, isTypeDefinition);
+                    }
                 }
 
                 return;


### PR DESCRIPTION
## Description
- Now only outputs full type signature if allow write sub type is true.
- Minor code style improvements.

## Motivation and Context
- When writing return type for MethodDef it was outputting the complete type signature for generic types (and arrays). This was overflowing the record size. It's not required as this is a helper information for the CLR to speed up processing of operations that depend on the return type. Ends up that for that purpose it suffices to write only the data type.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests in MDP.
- Parsing mscorlib implementing Span<>().
[tested against nanoclr buildId 55854]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
