### PR TITLE
Fix TypeRef for generic types

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
@@ -1,4 +1,4 @@
-// Licensed to the .NET Foundation under one or more agreements.
+﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
 // Original work from Oleg Rakhmatulin.
@@ -477,7 +477,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                 if (alsoWriteSubType)
                 {
                     GenericInstanceType genericType = (GenericInstanceType)typeDefinition;
-                    WriteDataType(genericType.Resolve(), writer, true, expandEnumType, isTypeDefinition);
+                    WriteDataType(genericType.ElementType, writer, true, expandEnumType, isTypeDefinition);
 
                     // OK to use byte here as we won't support more than 0x7F arguments
                     writer.WriteByte((byte)genericType.GenericArguments.Count);

--- a/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
@@ -269,8 +269,10 @@ namespace nanoFramework.Tools.MetadataProcessor
             else if (memberReference is MethodReference &&
                  MethodReferencesTable.TryGetMethodReferenceId(memberReference as MethodReference, out referenceId))
             {
-                // check if method is external
-                if (memberReference.DeclaringType.Scope.MetadataScopeType == MetadataScopeType.AssemblyNameReference)
+                // check if method is external, unless it's a closed generic instance
+                if (memberReference.DeclaringType.Scope.MetadataScopeType == MetadataScopeType.AssemblyNameReference
+                    && !(memberReference.DeclaringType is GenericInstanceType genericInstanceType
+                    && genericInstanceType.HasGenericArguments))
                 {
                     // method reference is external
                 }

--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -829,11 +829,6 @@ namespace nanoFramework.Tools.MetadataProcessor
                                     set.Add(v.VariableType.GetElementType().MetadataToken);
                                 }
                             }
-                            else if (v.VariableType.IsValueType
-                                     && !v.VariableType.IsPrimitive)
-                            {
-                                set.Add(v.VariableType.MetadataToken);
-                            }
                             else if (v.VariableType is GenericInstanceType)
                             {
                                 // Cecil.Mono has a bug providing TypeSpecs Metadata tokens generic parameters variables, so we need to check against our internal table and build one from it
@@ -851,6 +846,11 @@ namespace nanoFramework.Tools.MetadataProcessor
                                 {
                                     Debug.Fail($"Couldn't find a TypeSpec entry for {v.VariableType}");
                                 }
+                            }
+                            else if (v.VariableType.IsValueType
+                                     && !v.VariableType.IsPrimitive)
+                            {
+                                set.Add(v.VariableType.MetadataToken);
                             }
                             else if (v.VariableType.IsPointer)
                             {
@@ -1051,7 +1051,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                                 {
                                     // add "fabricated" token for TypeSpec using the referenceId as RID
                                     set.Add(new MetadataToken(TokenType.TypeSpec, tsRid));
-                                    set.Add(ts.GetElementType().MetadataToken);
+                                    set.Add(ts.MetadataToken);
                                 }
                                 else
                                 {


### PR DESCRIPTION
## Description
- WriteDataType for generic instance now uses element type instead of resolving the type.
- MethodRef now properly encodes external members of closed and opened generic types.
- BuildDependency now grabs correct token for TypeSpecs.

## Motivation and Context
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests in MDP.
- Running test app from the PR adding `Span<T>` (still not being tested in pipeline)
[tested against nanoclr buildId 56187]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
