### PR TITLE
Add Span<T> to test app

### DIFF
--- a/MetadataProcessor.Tests/TestNFApp/Program.cs
+++ b/MetadataProcessor.Tests/TestNFApp/Program.cs
@@ -88,6 +88,10 @@ namespace TestNFApp
             Console.WriteLine("Null attributes tests");
             _ = new ClassWithNullAttribs();
 
+            // testing Span<>
+            Console.WriteLine("Span<> tests");
+            _ = new TestingSpan();
+
             Console.WriteLine("Exiting TestNFApp");
         }
 

--- a/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
+++ b/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
@@ -36,6 +36,7 @@
     <Compile Include="OneClassOverAll.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TestingSpan.cs" />
     <Compile Include="TestingDestructors.cs" />
     <Compile Include="TestingDelegates.cs" />
   </ItemGroup>

--- a/MetadataProcessor.Tests/TestNFApp/TestingSpan.cs
+++ b/MetadataProcessor.Tests/TestNFApp/TestingSpan.cs
@@ -1,0 +1,61 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+using TestNFClassLibrary;
+
+namespace TestNFApp
+{
+    public class TestingSpan
+    {
+        public TestingSpan()
+        {
+            int length = 3;
+
+            // base type
+            Console.WriteLine("+++ Span<int> tests");
+            Console.WriteLine();
+
+            Span<int> numbers = new Span<int>(new int[length]);
+            for (int i = 0; i < length; i++)
+            {
+                numbers[i] = i;
+            }
+
+            foreach (int number in numbers)
+            {
+                Console.WriteLine($">>{number.ToString()}");
+            }
+
+            // string type
+            Console.WriteLine("+++ Span<string> tests");
+            Console.WriteLine();
+
+            Span<string> strings = new Span<string>(new string[length]);
+            for (int i = 1; i < length; i++)
+            {
+                strings[i] = $">> '{i * 10}'";
+            }
+
+            foreach (string str in strings)
+            {
+                Console.WriteLine($">> '{str}'");
+            }
+
+            // class type
+            Console.WriteLine("+++ Span<ClassOnAnotherAssembly> tests");
+            Span<ClassOnAnotherAssembly> spanOfClass = new Span<ClassOnAnotherAssembly>(new ClassOnAnotherAssembly[length]);
+
+            for (int i = 0; i < length; i++)
+            {
+                spanOfClass[i] = new ClassOnAnotherAssembly(i * 100);
+            }
+
+            foreach (ClassOnAnotherAssembly item in spanOfClass)
+            {
+                Console.WriteLine($">> '{item.DummyProperty}'");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description
- Add new class with several `Span<T>` to test app.
- Update mscorlib sub-module @3a7b785

## Motivation and Context
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests in MDP.
[tested against nanoclr buildId 57028]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
