### PR TITLE
Fix stubs generation to support generics notation

### DIFF
--- a/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
+++ b/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Text.RegularExpressions;
 using Mono.Cecil;
 using nanoFramework.Tools.MetadataProcessor.Core.Extensions;
 
@@ -62,8 +63,8 @@ namespace nanoFramework.Tools.MetadataProcessor
                 (method.RVA == 0 && !method.IsAbstract))
             {
                 _currentCrc = Crc32.Compute(_name, CurrentCrc);
-                _currentCrc = Crc32.Compute(Encoding.ASCII.GetBytes(GetClassName(type)), CurrentCrc);
-                _currentCrc = Crc32.Compute(Encoding.ASCII.GetBytes(GetMethodName(method)), CurrentCrc);
+                _currentCrc = Crc32.Compute(Encoding.ASCII.GetBytes(GetSafeClassName(type)), CurrentCrc);
+                _currentCrc = Crc32.Compute(Encoding.ASCII.GetBytes(GetSafeMethodName(method)), CurrentCrc);
 
                 _methodsWithNativeImplementation++;
             }
@@ -73,25 +74,26 @@ namespace nanoFramework.Tools.MetadataProcessor
             }
         }
 
-        internal static string GetClassName(
-            TypeDefinition type)
+        internal static string GetSafeClassName(TypeDefinition type)
         {
-            return (type != null
-                ? string.Join("_", GetClassName(type.DeclaringType), type.Namespace, type.Name)
-                    .Replace(".", "_").TrimStart('_')
+            string className = (type != null
+                ? string.Join("_", GetSafeClassName(type.DeclaringType), type.Namespace, type.Name)
+                    .Replace(".", "_")
+                    .TrimStart('_')
                 : string.Empty);
+
+            return CleanupGenericName(className);
         }
 
-        internal static string GetMethodName(
-            MethodDefinition method)
+        internal static string GetSafeMethodName(MethodDefinition method)
         {
-            var name = string.Concat(method.Name, (method.IsStatic ? "___STATIC__" : "___"),
+            string name = string.Concat(method.Name, (method.IsStatic ? "___STATIC__" : "___"),
                 string.Join("__", GetAllParameters(method)));
 
-            var originalName = name.Replace(".", "_")
+            string originalName = name.Replace(".", "_")
                                 .Replace("/", "");
 
-            return originalName;
+            return CleanupGenericName(originalName);
         }
 
         private static IEnumerable<string> GetAllParameters(
@@ -192,7 +194,9 @@ namespace nanoFramework.Tools.MetadataProcessor
                 else
                 {
                     // this is not a generic, get full qualified type name
-                    return parameterType.FullName.Replace(".", String.Empty);
+                    string typeName = parameterType.FullName.Replace(".", String.Empty);
+
+                    return CleanupGenericName(typeName);
                 }
             }
         }
@@ -215,6 +219,15 @@ namespace nanoFramework.Tools.MetadataProcessor
         {
             return (_classNamesToExclude.Contains(td.FullName) ||
                     _classNamesToExclude.Contains(td.DeclaringType?.FullName));
+        }
+
+        internal static string CleanupGenericName(string name)
+        {
+            // Remove generic type notation: anything like <T>, <T1,T2>, `, etc.
+            string fixedName = name
+                    .Replace('`', '_');
+
+            return Regex.Replace(fixedName, @"<[^>]*>", string.Empty);
         }
     }
 }

--- a/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
+++ b/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
@@ -83,8 +83,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
 
         private void GenerateStubs()
         {
-            var generatedFiles = new List<string>();
-
             var classList = new AssemblyClassTable
             {
                 AssemblyName = _tablesContext.AssemblyDefinition.Name.Name,
@@ -96,14 +94,14 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
             {
                 if (ShouldIncludeType(c))
                 {
-                    var className = NativeMethodsCrc.GetClassName(c);
+                    string _safeClassName = NativeMethodsCrc.GetSafeClassName(c);
 
                     var classStubs = new AssemblyClassStubs
                     {
                         AssemblyName = _name,
-                        ClassHeaderFileName = className,
-                        ClassName = c.Name,
-                        ShortNameUpper = $"{_assemblyName}_{_safeProjectName}_{className}".ToUpper(),
+                        ClassHeaderFileName = _safeClassName,
+                        ClassName = NativeMethodsCrc.CleanupGenericName(c.Name),
+                        ShortNameUpper = $"{_assemblyName}_{_safeProjectName}_{_safeClassName}".ToUpper(),
                         RootNamespace = _assemblyName,
                         ProjectName = _safeProjectName,
                         HeaderFileName = _safeProjectName
@@ -111,7 +109,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
 
                     classList.Classes.Add(new Class()
                     {
-                        Name = className
+                        Name = _safeClassName
                     });
                     classList.HeaderFileName = classStubs.HeaderFileName;
 
@@ -125,7 +123,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                         {
                             var newMethod = new MethodStub()
                             {
-                                Declaration = $"Library_{_safeProjectName}_{className}::{NativeMethodsCrc.GetMethodName(m)}"
+                                Declaration = $"Library_{_safeProjectName}_{_safeClassName}::{NativeMethodsCrc.GetSafeMethodName(m)}"
                             };
 
                             if (!_withoutInteropCode)
@@ -143,10 +141,10 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
 
                                 newMethod.MarshallingReturnType = m.MethodReturnType.ReturnType.ToCLRTypeAsString();
 
-                                declaration.Append($"{m.Name}");
+                                declaration.Append($"{NativeMethodsCrc.CleanupGenericName(m.Name)}");
                                 declaration.Append("( ");
 
-                                StringBuilder marshallingCall = new StringBuilder($"{m.Name}");
+                                StringBuilder marshallingCall = new StringBuilder($"{NativeMethodsCrc.CleanupGenericName(m.Name)}");
                                 marshallingCall.Append("( ");
 
                                 // loop through the parameters
@@ -259,16 +257,16 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                             };
                             Generator generator = compiler.Compile(SkeletonTemplates.ClassWithoutInteropStubTemplate);
 
-                            using (var headerFile = File.CreateText(Path.Combine(_path, $"{_safeProjectName}_{className}.cpp")))
+                            using (StreamWriter headerFile = File.CreateText(Path.Combine(_path, $"{_safeProjectName}_{_safeClassName}.cpp")))
                             {
-                                var output = generator.Render(classStubs);
+                                string output = generator.Render(classStubs);
                                 headerFile.Write(output);
                             }
 
                             // add class to list of classes with stubs
                             classList.ClassesWithStubs.Add(new ClassWithStubs()
                             {
-                                Name = className
+                                Name = _safeClassName
                             });
                         }
                         else
@@ -281,34 +279,34 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                             // user code stub
                             Generator generator = compiler.Compile(SkeletonTemplates.ClassStubTemplate);
 
-                            using (var headerFile = File.CreateText(Path.Combine(_path, $"{_safeProjectName}_{className}.cpp")))
+                            using (StreamWriter headerFile = File.CreateText(Path.Combine(_path, $"{_safeProjectName}_{_safeClassName}.cpp")))
                             {
-                                var output = generator.Render(classStubs);
+                                string output = generator.Render(classStubs);
                                 headerFile.Write(output);
                             }
 
                             // marshal code
                             generator = compiler.Compile(SkeletonTemplates.ClassMarshallingCodeTemplate);
 
-                            using (var headerFile = File.CreateText(Path.Combine(_path, $"{_safeProjectName}_{className}_mshl.cpp")))
+                            using (StreamWriter headerFile = File.CreateText(Path.Combine(_path, $"{_safeProjectName}_{_safeClassName}_mshl.cpp")))
                             {
-                                var output = generator.Render(classStubs);
+                                string output = generator.Render(classStubs);
                                 headerFile.Write(output);
                             }
 
                             // class header
                             generator = compiler.Compile(SkeletonTemplates.ClassHeaderTemplate);
 
-                            using (var headerFile = File.CreateText(Path.Combine(_path, $"{_safeProjectName}_{className}.h")))
+                            using (StreamWriter headerFile = File.CreateText(Path.Combine(_path, $"{_safeProjectName}_{_safeClassName}.h")))
                             {
-                                var output = generator.Render(classStubs);
+                                string output = generator.Render(classStubs);
                                 headerFile.Write(output);
                             }
 
                             // add class to list of classes with stubs
                             classList.ClassesWithStubs.Add(new ClassWithStubs()
                             {
-                                Name = className
+                                Name = _safeClassName
                             });
                         }
                     }
@@ -379,7 +377,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                 {
                     if (ShouldIncludeType(c))
                     {
-                        var className = NativeMethodsCrc.GetClassName(c);
+                        var className = NativeMethodsCrc.GetSafeClassName(c);
 
                         foreach (var m in nanoTablesContext.GetOrderedMethods(c.Methods))
                         {
@@ -392,7 +390,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                             {
                                 assemblyLookup.LookupTable.Add(new MethodStub()
                                 {
-                                    Declaration = $"Library_{_safeProjectName}_{className}::{NativeMethodsCrc.GetMethodName(m)}"
+                                    Declaration = $"Library_{_safeProjectName}_{className}::{NativeMethodsCrc.GetSafeMethodName(m)}"
                                 });
                             }
                             else
@@ -458,7 +456,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     var classData = new Class()
                     {
                         AssemblyName = _safeProjectName,
-                        Name = NativeMethodsCrc.GetClassName(c)
+                        Name = NativeMethodsCrc.GetSafeClassName(c)
                     };
 
                     // If class name starts from <PrivateImplementationDetails>,
@@ -525,7 +523,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                             {
                                 classData.Methods.Add(new MethodStub()
                                 {
-                                    Declaration = NativeMethodsCrc.GetMethodName(m)
+                                    Declaration = NativeMethodsCrc.GetSafeMethodName(m)
                                 });
                             }
                         }

--- a/MetadataProcessor.Tests/Core/Utility/NativeMethodsCrcTests.cs
+++ b/MetadataProcessor.Tests/Core/Utility/NativeMethodsCrcTests.cs
@@ -18,14 +18,28 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             var typeDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllTypeDefinition(nanoTablesContext.AssemblyDefinition);
 
             // test
-            var r = NativeMethodsCrc.GetClassName(typeDefinition);
+            var r = NativeMethodsCrc.GetSafeClassName(typeDefinition);
 
             Assert.AreEqual("TestNFApp_OneClassOverAll", r);
 
             // test
-            r = NativeMethodsCrc.GetClassName(null);
+            r = NativeMethodsCrc.GetSafeClassName(null);
 
             Assert.AreEqual(String.Empty, r);
+        }
+
+        [TestMethod]
+        public void GetClassNameWithGenericsTest()
+        {
+            nanoTablesContext nanoTablesContext = TestObjectHelper.GetTestNFAppNanoTablesContext();
+            TypeDefinition genericTypeDefinition = TestObjectHelper.GetTestNFAppGenericClassTypeDefinition(nanoTablesContext.AssemblyDefinition);
+            TypeDefinition anotherGenericTypeDefinition = TestObjectHelper.GetTestNFAppAnotherGenericClassTypeDefinition(nanoTablesContext.AssemblyDefinition);
+
+            // test
+            Assert.AreEqual("TestNFApp_GenericClass_1", NativeMethodsCrc.GetSafeClassName(genericTypeDefinition));
+            Assert.AreEqual("TestNFApp_AnotherGenericClass_2", NativeMethodsCrc.GetSafeClassName(anotherGenericTypeDefinition));
+
+            Assert.AreEqual(String.Empty, NativeMethodsCrc.GetSafeClassName(null));
         }
 
         [TestMethod]
@@ -36,7 +50,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             var methodDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllDummyMethodDefinition(typeDefinition);
 
             // test
-            var r = NativeMethodsCrc.GetMethodName(methodDefinition);
+            var r = NativeMethodsCrc.GetSafeMethodName(methodDefinition);
 
             Assert.AreEqual("DummyMethod___VOID", r);
 
@@ -45,7 +59,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             methodDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllDummyMethodWithParamsDefinition(typeDefinition);
 
             // test
-            r = NativeMethodsCrc.GetMethodName(methodDefinition);
+            r = NativeMethodsCrc.GetSafeMethodName(methodDefinition);
 
             Assert.AreEqual("DummyMethodWithParams___VOID__I4__STRING", r);
 
@@ -54,7 +68,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             methodDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllDummyStaticMethodDefinition(typeDefinition);
 
             // test
-            r = NativeMethodsCrc.GetMethodName(methodDefinition);
+            r = NativeMethodsCrc.GetSafeMethodName(methodDefinition);
 
             Assert.AreEqual("DummyStaticMethod___STATIC__VOID", r);
 
@@ -63,7 +77,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             methodDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllDummyStaticMethodWithParamsDefinition(typeDefinition);
 
             // test
-            r = NativeMethodsCrc.GetMethodName(methodDefinition);
+            r = NativeMethodsCrc.GetSafeMethodName(methodDefinition);
 
             Assert.AreEqual("DummyStaticMethodWithParams___STATIC__VOID__I8__SystemDateTime", r);
 

--- a/MetadataProcessor.Tests/StubsGenerationTestNFApp/NativeMethodGenerationGenerics.cs
+++ b/MetadataProcessor.Tests/StubsGenerationTestNFApp/NativeMethodGenerationGenerics.cs
@@ -1,0 +1,35 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+namespace StubsGenerationTestNFApp
+{
+    internal class NativeMethodGenerationGenerics<T>
+    {
+        public void Method<U>()
+        {
+            NativeMethod();
+
+            byte a = 0;
+            ushort b = 0;
+            U genParam = default;
+
+            NativeMethodWithReferenceParameters<T, U>(ref a, ref b);
+            
+            NativeStaticMethod<U>(default);
+        }
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern void NativeMethod();
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private extern void NativeMethodWithReferenceParameters<U, V>(ref byte refByteParam, ref ushort refUshortParam);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern void NativeStaticMethod<U>(T genParam);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        private static extern T NativeStaticMethodReturningType(char charParam);
+    }
+}

--- a/MetadataProcessor.Tests/StubsGenerationTestNFApp/Program.cs
+++ b/MetadataProcessor.Tests/StubsGenerationTestNFApp/Program.cs
@@ -9,8 +9,12 @@ namespace StubsGenerationTestNFApp
     {
         public static void Main()
         {
-            var nativeMethods = new NativeMethodGeneration();
+            NativeMethodGeneration nativeMethods = new NativeMethodGeneration();
             nativeMethods.Method();
+
+            NativeMethodGenerationGenerics<int> nativeMethodGenerationGenerics = new NativeMethodGenerationGenerics<int>();
+
+            nativeMethodGenerationGenerics.Method<int>();
 
             Thread.Sleep(Timeout.Infinite);
         }

--- a/MetadataProcessor.Tests/StubsGenerationTestNFApp/StubsGenerationTestNFApp.nfproj
+++ b/MetadataProcessor.Tests/StubsGenerationTestNFApp/StubsGenerationTestNFApp.nfproj
@@ -16,8 +16,12 @@
     <AssemblyName>StubsGenerationTestNFApp</AssemblyName>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
   </PropertyGroup>
+  <PropertyGroup Label="nanoFramework">
+    <NFMDP_GENERATE_STUBS>True</NFMDP_GENERATE_STUBS>
+  </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>
+    <Compile Include="NativeMethodGenerationGenerics.cs" />
     <Compile Include="NativeMethodGeneration.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MetadataProcessor.Tests/TestObjectHelper.cs
+++ b/MetadataProcessor.Tests/TestObjectHelper.cs
@@ -276,6 +276,22 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests
             return ret;
         }
 
+        public static TypeDefinition GetTestNFAppGenericClassTypeDefinition(AssemblyDefinition assemblyDefinition)
+        {
+            TypeDefinition ret = null;
+            ModuleDefinition module = assemblyDefinition.Modules[0];
+            ret = module.Types.First(i => i.FullName == "TestNFApp.GenericClass`1");
+            return ret;
+        }
+
+        public static TypeDefinition GetTestNFAppAnotherGenericClassTypeDefinition(AssemblyDefinition assemblyDefinition)
+        {
+            TypeDefinition ret = null;
+            ModuleDefinition module = assemblyDefinition.Modules[0];
+            ret = module.Types.First(i => i.FullName == "TestNFApp.AnotherGenericClass`2");
+            return ret;
+        }
+
         public static MethodDefinition GetTestNFAppOneClassOverAllDummyMethodDefinition(TypeDefinition oneClassOverAllTypeDefinition)
         {
             MethodDefinition ret = GetTestNFAppOneClassOverAllMethodDefinition(oneClassOverAllTypeDefinition, "DummyMethod");


### PR DESCRIPTION
## Description
- Rework naming parsers to remove/replace generic notation.
- Update code accordingly.
- Add new tests for generic instances.

## Motivation and Context
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests in MDP.
[tested against nanoclr buildId 56300]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
