### PR TITLE
Attribute value now accepts null string

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
@@ -817,7 +817,15 @@ namespace nanoFramework.Tools.MetadataProcessor
                         break;
                     case NanoCLRDataType.DATATYPE_STRING:
                         writer.Write((byte)nanoSerializationType.ELEMENT_TYPE_STRING);
-                        writer.Write(_context.StringTable.GetOrCreateStringId((string)argument.Value));
+                        if (argument.Value == null)
+                        {
+                            // write sentinel for null string
+                            writer.Write((ushort)0xFFFF);
+                        }
+                        else
+                        {
+                            writer.Write(_context.StringTable.GetOrCreateStringId((string)argument.Value));
+                        }
                         break;
                     default:
                         Debug.Fail(dataType.ToString());

--- a/MetadataProcessor.Tests/TestNFApp/MyClass1.cs
+++ b/MetadataProcessor.Tests/TestNFApp/MyClass1.cs
@@ -31,6 +31,11 @@ namespace TestNFApp
         {
         }
 
+        [DataRow(999, null)]
+        public void MyMethodWithDataRowWithNull()
+        {
+        }
+
         private readonly int _myField;
 
         [Ignore("I'm ignoring you!")]


### PR DESCRIPTION
## Description
- When serializing element type string now checks for null and uses a sentinel value instead of the string ID.
- Add `DataRow()` with null element to test app.

## Motivation and Context
- Add support for attributes with `null`.
- Native support (required!!) added with nanoframework/nf-interpreter#3190
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests in MDP.
[tested against nanoclr buildId 56308]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
