### PR TITLE
Improve TypeRef equality comparer

### DIFF
--- a/MetadataProcessor.Shared/Utility/TypeReferenceEqualityComparer.cs
+++ b/MetadataProcessor.Shared/Utility/TypeReferenceEqualityComparer.cs
@@ -79,13 +79,17 @@ namespace nanoFramework.Tools.MetadataProcessor
                 // provide an hash code based on the TypeSpec signature 
                 return xSignatureId;
             }
-            else if (obj is GenericParameter)
+            else if (obj is GenericParameter genericParam)
             {
                 // provide an hash code based on the generic parameter position and type, 
                 // which is what makes it unique when comparing GenericParameter as a TypeReference
-                var genericParam = obj as GenericParameter;
 
-                return genericParam.Position * 10 + (int)genericParam.Type;
+                int hash = 17;
+                hash = unchecked(hash * 31 + genericParam.DeclaringType?.MetadataToken.ToInt32() ?? 0);
+                hash = unchecked(hash * 31 + genericParam.Position);
+                hash = unchecked(hash * 31 + (int)genericParam.Type);
+
+                return hash;
             }
             else
             {


### PR DESCRIPTION
## Description
- Now using a more complex algorithm to generate hash code for generic parameter.

## Motivation and Context
- Previous computation with just type and position was too weak.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Running unit tests in MDP.
[tested against nanoclr buildId 56308]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
