### PR TITLE
Fix FieldRef and FieldDef

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoFieldDefinitionTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoFieldDefinitionTable.cs
@@ -22,7 +22,7 @@ namespace nanoFramework.Tools.MetadataProcessor
         //////////////////////////////////////////////////////////////////////////////////////////////
         // <SYNC-WITH-NATIVE>                                                                       //
         // when updating this size here need to update matching define in nanoCLR_Types.h in native //
-        private const int sizeOf_CLR_RECORD_FIELDDEF = 8;
+        private const int sizeOf_CLR_RECORD_FIELDDEF = 10;
         //////////////////////////////////////////////////////////////////////////////////////////////
         //////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -35,13 +35,13 @@ namespace nanoFramework.Tools.MetadataProcessor
             /// <inheritdoc/>
             public bool Equals(FieldDefinition lhs, FieldDefinition rhs)
             {
-                return string.Equals(lhs.FullName, rhs.FullName, StringComparison.Ordinal);
+                return lhs.MetadataToken.Equals(rhs.MetadataToken);
             }
 
             /// <inheritdoc/>
             public int GetHashCode(FieldDefinition that)
             {
-                return that.FullName.GetHashCode();
+                return that.MetadataToken.GetHashCode();
             }
         }
 
@@ -81,6 +81,7 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             var writerStartPosition = writer.BaseStream.Position;
 
+            WriteStringReference(writer, item.DeclaringType.Name);
             WriteStringReference(writer, item.Name);
             writer.WriteUInt16(_context.SignaturesTable.GetOrCreateSignatureId(item));
 

--- a/MetadataProcessor.Shared/Tables/nanoFieldReferenceTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoFieldReferenceTable.cs
@@ -22,7 +22,7 @@ namespace nanoFramework.Tools.MetadataProcessor
         //////////////////////////////////////////////////////////////////////////////////////////////
         // <SYNC-WITH-NATIVE>                                                                       //
         // when updating this size here need to update matching define in nanoCLR_Types.h in native //
-        private const int sizeOf_CLR_RECORD_FIELDREF = 6;
+        private const int sizeOf_CLR_RECORD_FIELDREF = 8;
         //////////////////////////////////////////////////////////////////////////////////////////////
         //////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -35,13 +35,13 @@ namespace nanoFramework.Tools.MetadataProcessor
             /// <inheritdoc/>
             public bool Equals(FieldReference lhs, FieldReference rhs)
             {
-                return string.Equals(lhs.FullName, rhs.FullName, StringComparison.Ordinal);
+                return lhs.MetadataToken.Equals(rhs.MetadataToken);
             }
 
             /// <inheritdoc/>
             public int GetHashCode(FieldReference that)
             {
-                return that.FullName.GetHashCode();
+                return that.MetadataToken.GetHashCode();
             }
         }
 
@@ -98,6 +98,9 @@ namespace nanoFramework.Tools.MetadataProcessor
             {
                 throw new ArgumentException($"Can't find a type reference for {item.DeclaringType}.");
             }
+
+            // Type
+            WriteStringReference(writer, item.DeclaringType.Name);
 
             // Name
             WriteStringReference(writer, item.Name);


### PR DESCRIPTION
## Description
- Now storing type name too as this is required for disambiguation.

## Motivation and Context
- Comparing the signature is not enough with generics as generic params can have the same signature. Need the combination type+field name to fully disambiguate.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- [tested against nanoclr buildId 56528]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
