### PR TITLE
Rename TryGetFieldReferenceId to Definition

### DIFF
--- a/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
+++ b/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
@@ -148,7 +148,7 @@ namespace nanoFramework.Tools.MetadataProcessor
     {
         public Field(nanoTablesContext context, FieldDefinition field)
         {
-            context.FieldsTable.TryGetFieldReferenceId(field, false, out ushort fieldToken);
+            context.FieldsTable.TryGetFieldDefinitionId(field, false, out ushort fieldToken);
 
             Token = new Token(field.MetadataToken, NanoClrTable.TBL_FieldDef.ToNanoTokenType() | fieldToken);
 

--- a/MetadataProcessor.Shared/Tables/nanoFieldDefinitionTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoFieldDefinitionTable.cs
@@ -94,22 +94,24 @@ namespace nanoFramework.Tools.MetadataProcessor
         }
 
         /// <summary>
-        /// Gets field reference identifier (if field is defined inside target assembly).
+        /// Gets field definition identifier (if field is defined inside target assembly).
         /// </summary>
         /// <param name="field">Field definition in Mono.Cecil format.</param>
-        /// <param name="trackMaxReferenceId">If set to <c>true</c> we should track max ID value.</param>
-        /// <param name="referenceId">Field reference identifier for filling.</param>
+        /// <param name="trackMaxDefinitionId">If set to <c>true</c> we should track max ID value.</param>
+        /// <param name="definitionId">Field definition identifier for filling.</param>
         /// <returns>Returns <c>true</c> if item found, otherwise returns <c>false</c>.</returns>
-        public bool TryGetFieldReferenceId(
+        public bool TryGetFieldDefinitionId(
             FieldDefinition field,
-            bool trackMaxReferenceId,
-            out ushort referenceId)
+            bool trackMaxDefinitionId,
+            out ushort definitionId)
         {
-            var found = TryGetIdByValue(field, out referenceId);
-            if (trackMaxReferenceId && found)
+            bool found = TryGetIdByValue(field, out definitionId);
+
+            if (trackMaxDefinitionId && found)
             {
-                _maxReferenceId = Math.Max(_maxReferenceId, referenceId + 1);
+                _maxReferenceId = Math.Max(_maxReferenceId, definitionId + 1);
             }
+
             return found;
         }
 

--- a/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
@@ -324,7 +324,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             if (fieldReference is FieldDefinition)
             {
                 // field definition is internal
-                if (FieldsTable.TryGetFieldReferenceId(fieldReference as FieldDefinition, false, out referenceId))
+                if (FieldsTable.TryGetFieldDefinitionId(fieldReference as FieldDefinition, false, out referenceId))
                 {
                     // field reference is internal => field definition
                     ownerTable = NanoClrTable.TBL_FieldDef;
@@ -381,7 +381,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                     TypeSpecificationsTable.TryGetTypeReferenceId((TypeReference)token, out referenceId);
                     return (uint)0x09000000 | referenceId;
                 case TokenType.Field:
-                    FieldsTable.TryGetFieldReferenceId((FieldDefinition)token, false, out referenceId);
+                    FieldsTable.TryGetFieldDefinitionId((FieldDefinition)token, false, out referenceId);
                     return (uint)0x05000000 | referenceId;
                 case TokenType.GenericParam:
                     GenericParamsTable.TryGetParameterId((GenericParameter)token, out referenceId);

--- a/MetadataProcessor.Shared/Tables/nanoTypeDefinitionTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeDefinitionTable.cs
@@ -229,7 +229,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             foreach (var field in fieldsList.Where(item => item.IsStatic))
             {
                 ushort fieldReferenceId;
-                if (_context.FieldsTable.TryGetFieldReferenceId(field, false, out fieldReferenceId))
+                if (_context.FieldsTable.TryGetFieldDefinitionId(field, false, out fieldReferenceId))
                 {
                     if (staticFieldsCount == 0)
                     {
@@ -254,7 +254,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             foreach (var field in fieldsList.Where(item => !item.IsStatic))
             {
                 ushort fieldReferenceId;
-                if (_context.FieldsTable.TryGetFieldReferenceId(field, false, out fieldReferenceId))
+                if (_context.FieldsTable.TryGetFieldDefinitionId(field, false, out fieldReferenceId))
                 {
                     if (instanceFieldsCount == 0)
                     {

--- a/MetadataProcessor.Shared/Utility/nanoDependencyGeneratorWriter.cs
+++ b/MetadataProcessor.Shared/Utility/nanoDependencyGeneratorWriter.cs
@@ -194,7 +194,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             foreach (var field in fields.Where(item => !item.HasConstant))
             {
                 ushort fieldToken;
-                _context.FieldsTable.TryGetFieldReferenceId(field, false, out fieldToken);
+                _context.FieldsTable.TryGetFieldDefinitionId(field, false, out fieldToken);
                 yield return new Tuple<uint, uint>(
                     field.MetadataToken.ToUInt32(), 0x05000000 | (uint)fieldToken);
             }

--- a/MetadataProcessor.Shared/nanoDumperGenerator.cs
+++ b/MetadataProcessor.Shared/nanoDumperGenerator.cs
@@ -328,7 +328,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     uint att = (uint)f.Attributes;
 
                     string realToken = f.MetadataToken.ToInt32().ToString("X8");
-                    _tablesContext.FieldsTable.TryGetFieldReferenceId(f, false, out referenceId);
+                    _tablesContext.FieldsTable.TryGetFieldDefinitionId(f, false, out referenceId);
 
                     var fieldDef = new FieldDef()
                     {
@@ -784,7 +784,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                             Signature = fd.FieldType.TypeSignatureAsString()
                         };
 
-                        if (_tablesContext.FieldsTable.TryGetFieldReferenceId(fd, false, out ushort fieldId))
+                        if (_tablesContext.FieldsTable.TryGetFieldDefinitionId(fd, false, out ushort fieldId))
                         {
                             realToken = fd.MetadataToken.ToInt32().ToString("X8");
                             memberRef.ReferenceId = $"[{new nanoMetadataToken(NanoClrTable.TBL_FieldDef, fieldId)}] /*{realToken}*/";

--- a/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
+++ b/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
@@ -498,7 +498,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     {
                         FixFieldName(f, out string fixedFieldName, out string fieldWarning);
 
-                        if (_tablesContext.FieldsTable.TryGetFieldReferenceId(f, false, out ushort fieldRefId))
+                        if (_tablesContext.FieldsTable.TryGetFieldDefinitionId(f, false, out ushort fieldRefId))
                         {
                             classData.InstanceFields.Add(new InstanceField()
                             {

--- a/MetadataProcessor.Tests/Core/Utility/DumperTests.cs
+++ b/MetadataProcessor.Tests/Core/Utility/DumperTests.cs
@@ -92,15 +92,15 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
 
             FieldDefinition maxField = nanoTablesContext.FieldsTable.Items.FirstOrDefault(f => f.Name == "_max");
             string maxFieldRealToken = maxField.MetadataToken.ToInt32().ToString("X8");
-            nanoTablesContext.FieldsTable.TryGetFieldReferenceId(maxField, false, out ushort maxFieldReferenceId);
+            nanoTablesContext.FieldsTable.TryGetFieldDefinitionId(maxField, false, out ushort maxFieldReferenceId);
 
             FieldDefinition sField = nanoTablesContext.FieldsTable.Items.FirstOrDefault(f => f.Name == "_s");
             string sFieldRealToken = sField.MetadataToken.ToInt32().ToString("X8");
-            nanoTablesContext.FieldsTable.TryGetFieldReferenceId(sField, false, out ushort sFieldReferenceId);
+            nanoTablesContext.FieldsTable.TryGetFieldDefinitionId(sField, false, out ushort sFieldReferenceId);
 
             FieldDefinition bField = nanoTablesContext.FieldsTable.Items.FirstOrDefault(f => f.Name == "_b");
             string bFieldRealToken = bField.MetadataToken.ToInt32().ToString("X8");
-            nanoTablesContext.FieldsTable.TryGetFieldReferenceId(bField, false, out ushort bFieldReferenceId);
+            nanoTablesContext.FieldsTable.TryGetFieldDefinitionId(bField, false, out ushort bFieldReferenceId);
 
 
             typeFlags = (uint)nanoTypeDefinitionTable.GetFlags(type1, nanoTablesContext.MethodDefinitionTable);


### PR DESCRIPTION
## Description
- Rename TryGetFieldReferenceId to TryGetFieldDefinitionId.
- Update callers accordingly.

## Motivation and Context
- The method name was misleading, potentially confusing with FieldRef.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- [tested against nanoclr buildId 56663].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
