### PR TITLE
Fix writting MethodSpec

### DIFF
--- a/MetadataProcessor.Shared/Extensions/MethodSpecificationExtensions.cs
+++ b/MetadataProcessor.Shared/Extensions/MethodSpecificationExtensions.cs
@@ -21,28 +21,15 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
 
         public static NanoClrTable ToNanoCLRTable(this MethodSpecification value)
         {
-            // this one has to be before the others because generic parameters are also "other" types
-            if (value.Resolve() is MethodDefinition)
+            if (value.DeclaringType.Scope.MetadataScopeType == MetadataScopeType.AssemblyNameReference)
             {
-                return NanoClrTable.TBL_MethodDef;
-            }
-            else if (value.Resolve() is MethodReference ||
-                    value.Resolve() is MethodSpecification)
-            {
-                if (value.DeclaringType.Scope.MetadataScopeType == MetadataScopeType.AssemblyNameReference)
-                {
-                    // method ref is external
-                    return NanoClrTable.TBL_MethodRef;
-                }
-                else
-                {
-                    // method ref is internal
-                    return NanoClrTable.TBL_MethodDef;
-                }
+                // method ref is external
+                return NanoClrTable.TBL_MethodRef;
             }
             else
             {
-                throw new ArgumentException("Unknown conversion to CLR Table.");
+                // method ref is internal
+                return NanoClrTable.TBL_MethodDef;
             }
         }
     }

--- a/MetadataProcessor.Shared/Tables/nanoMethodSpecificationTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoMethodSpecificationTable.cs
@@ -103,7 +103,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             {
                 // method is method def
             }
-            else if (_context.MethodReferencesTable.TryGetMethodReferenceId(item.Resolve(), out referenceId))
+            else if (_context.MethodReferencesTable.TryGetMethodReferenceId(item.ElementMethod, out referenceId))
             {
                 // method is method ref
             }

--- a/MetadataProcessor.Shared/Tables/nanoMethodSpecificationTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoMethodSpecificationTable.cs
@@ -76,14 +76,14 @@ namespace nanoFramework.Tools.MetadataProcessor
         /// <summary>
         /// Gets method specification ID if possible.
         /// </summary>
-        /// <param name="genericParameter">Method reference metadata in Mono.Cecil format.</param>
+        /// <param name="methodSpec">Method reference metadata in Mono.Cecil format.</param>
         /// <param name="referenceId">Method reference ID in .NET nanoFramework format.</param>
         /// <returns>Returns <c>true</c> if reference found, otherwise returns <c>false</c>.</returns>
         public bool TryGetMethodSpecificationId(
-            MethodSpecification genericParameter,
+            MethodSpecification methodSpec,
             out ushort referenceId)
         {
-            return TryGetIdByValue(genericParameter, out referenceId);
+            return TryGetIdByValue(methodSpec, out referenceId);
         }
 
         /// <inheritdoc/>
@@ -99,13 +99,13 @@ namespace nanoFramework.Tools.MetadataProcessor
             var writerStartPosition = writer.BaseStream.Position;
 
             // Method
-            if (_context.MethodDefinitionTable.TryGetMethodReferenceId(item.Resolve(), out ushort referenceId))
+            if (_context.MethodSpecificationTable.TryGetMethodSpecificationId(item, out ushort referenceId))
             {
-                // method is method definition
+                // method is method spec
             }
             else
             {
-                Debug.Fail($"Can't find a reference for {item.Resolve()}");
+                Debug.Fail($"Can't find a reference for {item}");
             }
 
             writer.WriteUInt16((ushort)(item.ToEncodedNanoMethodToken() | referenceId));

--- a/MetadataProcessor.Shared/Tables/nanoMethodSpecificationTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoMethodSpecificationTable.cs
@@ -99,9 +99,13 @@ namespace nanoFramework.Tools.MetadataProcessor
             var writerStartPosition = writer.BaseStream.Position;
 
             // Method
-            if (_context.MethodSpecificationTable.TryGetMethodSpecificationId(item, out ushort referenceId))
+            if (_context.MethodDefinitionTable.TryGetMethodReferenceId(item.Resolve(), out ushort referenceId))
             {
-                // method is method spec
+                // method is method def
+            }
+            else if (_context.MethodReferencesTable.TryGetMethodReferenceId(item.Resolve(), out referenceId))
+            {
+                // method is method ref
             }
             else
             {


### PR DESCRIPTION
## Description
- Now is referencing correct table.
- Not resolving method anymore.
- Fix parameter name for consistency.
- Simplified encoding of method ref/def table.

## Motivation and Context
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- [tested against nanoclr buildId 56902].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
