### PR TITLE
MethodDef comparer now also uses name to disambiguate

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoMethodDefinitionTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoMethodDefinitionTable.cs
@@ -33,7 +33,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             /// <inheritdoc/>
             public bool Equals(MethodDefinition lhs, MethodDefinition rhs)
             {
-                return lhs.MetadataToken.Equals(rhs.MetadataToken);
+                return lhs.MetadataToken.Equals(rhs.MetadataToken) && lhs.Name == rhs.Name;
             }
 
             /// <inheritdoc/>


### PR DESCRIPTION
## Description
- MethodDef comparer now also uses method name to help disambiguate.

## Motivation and Context
- The existing comparer was finding MethodDef that belong to another assembly, as it was comparing only the metadata token.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- [tested against nanoclr buildId 56947].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
