### PR TITLE
Change order of check for generic instance in dependency build

### DIFF
--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -631,15 +631,15 @@ namespace nanoFramework.Tools.MetadataProcessor
                     {
                         set.Add(fd.MetadataToken);
                     }
-                    else if (fd.FieldType.IsValueType &&
-                             !fd.FieldType.IsPrimitive)
-                    {
-                        set.Add(fd.FieldType.MetadataToken);
-                    }
                     else if (fd.FieldType is GenericInstanceType)
                     {
                         set.Add(fd.FieldType.MetadataToken);
                         set.Add(fd.FieldType.GetElementType().MetadataToken);
+                    }
+                    else if (fd.FieldType.IsValueType &&
+                             !fd.FieldType.IsPrimitive)
+                    {
+                        set.Add(fd.FieldType.MetadataToken);
                     }
                     else if (fd.FieldType.IsArray)
                     {
@@ -759,15 +759,15 @@ namespace nanoFramework.Tools.MetadataProcessor
                         {
                             set.Add(parameterType.MetadataToken);
                         }
-                        else if (parameterType.IsValueType &&
-                                 !parameterType.IsPrimitive)
-                        {
-                            set.Add(parameterType.MetadataToken);
-                        }
                         else if (parameterType is GenericInstanceType)
                         {
                             set.Add(parameterType.MetadataToken);
                             set.Add(parameterType.GetElementType().MetadataToken);
+                        }
+                        else if (parameterType.IsValueType &&
+                                 !parameterType.IsPrimitive)
+                        {
+                            set.Add(parameterType.MetadataToken);
                         }
                         else if (parameterType is GenericParameter)
                         {
@@ -914,15 +914,15 @@ namespace nanoFramework.Tools.MetadataProcessor
                                         set.Add(elementType.MetadataToken);
                                     }
                                 }
-                                else if (returnType.MetadataType == MetadataType.Class
-                                    || (returnType.IsValueType && !returnType.IsPrimitive))
-                                {
-                                    set.Add(returnType.MetadataToken);
-                                }
                                 else if (returnType is GenericInstanceType genericInstanceType)
                                 {
                                     set.Add(genericInstanceType.MetadataToken);
                                     set.Add(genericInstanceType.ElementType.MetadataToken);
+                                }
+                                else if (returnType.MetadataType == MetadataType.Class
+                                    || (returnType.IsValueType && !returnType.IsPrimitive))
+                                {
+                                    set.Add(returnType.MetadataToken);
                                 }
 
                                 // capture any *parameter* types
@@ -951,16 +951,17 @@ namespace nanoFramework.Tools.MetadataProcessor
                                             set.Add(elementType.MetadataToken);
                                         }
                                     }
-                                    else if (parameterType.MetadataType == MetadataType.Class
-                                        || (parameterType.IsValueType && !parameterType.IsPrimitive))
-                                    {
-                                        set.Add(parameterType.MetadataToken);
-                                    }
                                     else if (parameterType is GenericInstanceType genericInstanceType)
                                     {
                                         set.Add(genericInstanceType.MetadataToken);
                                         set.Add(genericInstanceType.ElementType.MetadataToken);
                                     }
+                                    else if (parameterType.MetadataType == MetadataType.Class
+                                        || (parameterType.IsValueType && !parameterType.IsPrimitive))
+                                    {
+                                        set.Add(parameterType.MetadataToken);
+                                    }
+
                                 }
 
                                 // after handling a GenericInstanceMethod, OK skip the other branches
@@ -1000,16 +1001,17 @@ namespace nanoFramework.Tools.MetadataProcessor
                                         set.Add(elementType.MetadataToken);
                                     }
                                 }
-                                else if (returnType.MetadataType == MetadataType.Class
-                                    || (returnType.IsValueType && !returnType.IsPrimitive))
-                                {
-                                    set.Add(returnType.MetadataToken);
-                                }
                                 else if (returnType is GenericInstanceType gitRt)
                                 {
                                     set.Add(gitRt.MetadataToken);
                                     set.Add(gitRt.ElementType.MetadataToken);
                                 }
+                                else if (returnType.MetadataType == MetadataType.Class
+                                    || (returnType.IsValueType && !returnType.IsPrimitive))
+                                {
+                                    set.Add(returnType.MetadataToken);
+                                }
+
 
                                 // capture any parameters
                                 foreach (ParameterDefinition p in ((MethodReference)i.Operand).Parameters)
@@ -1027,16 +1029,17 @@ namespace nanoFramework.Tools.MetadataProcessor
                                             set.Add(e.MetadataToken);
                                         }
                                     }
-                                    else if (typeReference.MetadataType == MetadataType.Class
-                                        || (typeReference.IsValueType && !typeReference.IsPrimitive))
-                                    {
-                                        set.Add(typeReference.MetadataToken);
-                                    }
                                     else if (typeReference is GenericInstanceType genericInstanceType)
                                     {
                                         set.Add(genericInstanceType.MetadataToken);
                                         set.Add(genericInstanceType.ElementType.MetadataToken);
                                     }
+                                    else if (typeReference.MetadataType == MetadataType.Class
+                                        || (typeReference.IsValueType && !typeReference.IsPrimitive))
+                                    {
+                                        set.Add(typeReference.MetadataToken);
+                                    }
+
                                 }
                             }
                             else if (i.Operand is MethodReference methodReference)
@@ -1201,16 +1204,17 @@ namespace nanoFramework.Tools.MetadataProcessor
 
                             set.Add(arr.ElementType.MetadataToken);
                         }
-                        else if (ret.MetadataType == MetadataType.Class
-                                 || (ret.IsValueType && !ret.IsPrimitive))
-                        {
-                            set.Add(ret.MetadataToken);
-                        }
                         else if (ret is GenericInstanceType genericInstanceType)
                         {
                             set.Add(genericInstanceType.MetadataToken);
                             set.Add(genericInstanceType.ElementType.MetadataToken);
                         }
+                        else if (ret.MetadataType == MetadataType.Class
+                                 || (ret.IsValueType && !ret.IsPrimitive))
+                        {
+                            set.Add(ret.MetadataToken);
+                        }
+
 
                         // pin each PARAMETER type as well
                         foreach (ParameterDefinition p in ms.Parameters)
@@ -1230,16 +1234,17 @@ namespace nanoFramework.Tools.MetadataProcessor
 
                                 set.Add(ap.ElementType.MetadataToken);
                             }
-                            else if (parameterType.MetadataType == MetadataType.Class
-                                     || (parameterType.IsValueType && !parameterType.IsPrimitive))
-                            {
-                                set.Add(parameterType.MetadataToken);
-                            }
                             else if (parameterType is GenericInstanceType genericInstanceType)
                             {
                                 set.Add(genericInstanceType.MetadataToken);
                                 set.Add(genericInstanceType.ElementType.MetadataToken);
                             }
+                            else if (parameterType.MetadataType == MetadataType.Class
+                                     || (parameterType.IsValueType && !parameterType.IsPrimitive))
+                            {
+                                set.Add(parameterType.MetadataToken);
+                            }
+
                         }
 
                         // pin generic parameters, if any


### PR DESCRIPTION
## Description
- Generic instance now comes before ValueType.

## Motivation and Context
- Generic types like `Span<T>` are value types which requires both the generic type and the closed type to be added to the dependency list.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
[tested against nanoclr buildId 57188].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
