### PR TITLE
Processing types to get TypeSpecs now collects generic instance variable

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
@@ -298,6 +298,11 @@ namespace nanoFramework.Tools.MetadataProcessor
 
                 foreach (MethodDefinition m in td.Methods.Where(m => m.HasBody))
                 {
+                    foreach (VariableDefinition variable in m.Body.Variables)
+                    {
+                        ExpandNestedTypeSpecs(variable.VariableType);
+                    }
+
                     foreach (Instruction instr in m.Body.Instructions)
                     {
                         if (instr.Operand is GenericInstanceMethod genericInstanceMethod)
@@ -398,6 +403,9 @@ namespace nanoFramework.Tools.MetadataProcessor
                     {
                         ExpandNestedTypeSpecs(arg);
                     }
+
+                    ushort declId = _context.SignaturesTable.GetOrCreateSignatureId(git);
+                    AddIfNew(git, declId);
 
                     break;
 


### PR DESCRIPTION
## Description
- Add processing of body variables as they can be a generic instance.

## Motivation and Context
- Minimization of assembly was failing because of this.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- [tested against nanoclr buildId 57675].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
