### PR TITLE
TypeSpec table is now minimized

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
@@ -471,16 +471,147 @@ namespace nanoFramework.Tools.MetadataProcessor
                     ushort gpSig = _context.SignaturesTable.GetOrCreateSignatureId(gp);
                     AddIfNew(gp, gpSig);
                 }
+            }
+        }
 
-                // seed the *open* GenericInstanceType (e.g. Action`1<T>)
-                var openGeneric = new GenericInstanceType(td);
-                foreach (GenericParameter gp in td.GenericParameters)
+        internal void RemoveEmptyItems()
+        {
+            var itemsToRemove = new List<TypeReference>();
+
+            foreach (var kvp in _idByTypeSpecifications.ToList())
+            {
+                TypeReference typeReference = kvp.Key;
+                ushort sigId = kvp.Value;
+
+                // Get the index of this TypeSpec in the collection
+                if (!TryGetTypeReferenceId(typeReference, out ushort index))
                 {
-                    openGeneric.GenericArguments.Add(gp);
+                    continue;
                 }
 
-                ushort openSig = _context.SignaturesTable.GetOrCreateSignatureId(openGeneric);
-                AddIfNew(openGeneric, openSig);
+                bool hasMemberReferences = false;
+
+                // Check if this TypeSpec has any member references
+                if (typeReference is GenericParameter)
+                {
+                    // Generic parameters might be referenced without explicit member refs
+                    // Keep them for now
+                    continue;
+                }
+                else if (typeReference.IsArray)
+                {
+                    // Arrays might be referenced without explicit member refs
+                    // Keep them for now
+                    continue;
+                }
+                else if (typeReference is ByReferenceType || typeReference is PointerType)
+                {
+                    // ByRef and Pointer types might be referenced without explicit member refs
+                    // Keep them for now
+                    continue;
+                }
+                else if (typeReference is GenericInstanceType genericInstanceType)
+                {
+                    // Check MethodReferencesTable
+                    foreach (MethodReference mr in _context.MethodReferencesTable.Items)
+                    {
+                        if (TryGetTypeReferenceId(mr.DeclaringType, out ushort referenceId)
+                            && referenceId == index
+                            && _context.MethodReferencesTable.TryGetMethodReferenceId(mr, out ushort _))
+                        {
+                            hasMemberReferences = true;
+                            break;
+                        }
+                    }
+
+                    // Check MethodSpecificationTable if no refs found yet
+                    if (!hasMemberReferences)
+                    {
+                        foreach (MethodSpecification ms in _context.MethodSpecificationTable.Items)
+                        {
+                            if (TryGetTypeReferenceId(ms.DeclaringType, out ushort referenceId)
+                                && referenceId == index
+                                && _context.MethodSpecificationTable.TryGetMethodSpecificationId(ms, out ushort _))
+                            {
+                                hasMemberReferences = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    // Check FieldReferencesTable if no refs found yet
+                    if (!hasMemberReferences)
+                    {
+                        foreach (FieldReference fr in _context.FieldReferencesTable.Items)
+                        {
+                            if (TryGetTypeReferenceId(fr.DeclaringType, out ushort referenceId)
+                                && referenceId == index
+                                && _context.FieldReferencesTable.TryGetFieldReferenceId(fr, out ushort _))
+                            {
+                                hasMemberReferences = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    // Check if the ElementType is a TypeDefinition with methods/fields
+                    if (!hasMemberReferences && genericInstanceType.ElementType is TypeDefinition definition)
+                    {
+                        // Check if any of the definition's methods are in MethodDefinitionTable
+                        foreach (MethodDefinition md in definition.Methods)
+                        {
+                            if (_context.MethodDefinitionTable.TryGetMethodReferenceId(md, out ushort _))
+                            {
+                                hasMemberReferences = true;
+                                break;
+                            }
+                        }
+
+                        // Check if any of the definition's fields are in FieldsTable
+                        if (!hasMemberReferences)
+                        {
+                            foreach (FieldDefinition fd in definition.Fields)
+                            {
+                                if (_context.FieldsTable.TryGetFieldDefinitionId(fd, false, out ushort _))
+                                {
+                                    hasMemberReferences = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    // For other TypeSpecification types (arrays, pointers, etc.)
+                    // check member references tables
+                    foreach (MemberReference mr in _context.MemberReferencesTable.Items)
+                    {
+                        try
+                        {
+                            if (TryGetTypeReferenceId(mr.DeclaringType, out ushort referenceId) && referenceId == index)
+                            {
+                                hasMemberReferences = true;
+                                break;
+                            }
+                        }
+                        catch
+                        {
+                            // ignore errors here, as the TypeSpec might not be available
+                        }
+                    }
+                }
+
+                if (!hasMemberReferences)
+                {
+                    itemsToRemove.Add(typeReference);
+                }
+            }
+
+            // Remove items that have no member references
+            foreach (var item in itemsToRemove)
+            {
+                _idByTypeSpecifications.Remove(item);
             }
         }
     }

--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -248,6 +248,8 @@ namespace nanoFramework.Tools.MetadataProcessor
                 interfacesToRemove.Select(i => c.Interfaces.Remove(i)).ToList();
             }
 
+            _tablesContext.TypeSpecificationsTable.RemoveEmptyItems();
+
             // flag minimize completed
             _tablesContext.MinimizeComplete = true;
         }


### PR DESCRIPTION
## Description
- Add method that crawls TypeSpec items and removes the unused/unnecessary ones.

## Motivation and Context
- Removes unused entries in this table thus reducing the PE file size.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- [tested against nanoclr buildId 57781].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
