### PR TITLE
Add support to process pointer parameters

### DIFF
--- a/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
+++ b/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
@@ -191,13 +191,18 @@ namespace nanoFramework.Tools.MetadataProcessor
                     // check if it's generic
                     return "DATATYPE_GENERICTYPE";
                 }
-                else
+                else if(parameterType.IsPointer)
                 {
-                    // this is not a generic, get full qualified type name
-                    string typeName = parameterType.FullName.Replace(".", String.Empty);
-
-                    return CleanupGenericName(typeName);
+                    if (nanoSignaturesTable.PrimitiveTypes.TryGetValue(parameterType.GetElementType().FullName, out myType))
+                    {
+                        return $"{myType}ptr";
+                    }
                 }
+
+                // last attempt: get full qualified type name
+                string typeName = parameterType.FullName.Replace(".", string.Empty);
+
+                return CleanupGenericName(typeName);
             }
         }
 

--- a/MetadataProcessor.Tests/StubsGenerationTestNFApp/NativeMethodGeneration.cs
+++ b/MetadataProcessor.Tests/StubsGenerationTestNFApp/NativeMethodGeneration.cs
@@ -27,5 +27,8 @@ namespace StubsGenerationTestNFApp
 
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern byte NativeStaticMethodReturningByte(char charParam);
+
+        [MethodImpl(MethodImplOptions.InternalCall)]
+        public extern unsafe void MethodWithPointerParm(void* pointer, int length);
     }
 }

--- a/MetadataProcessor.Tests/StubsGenerationTestNFApp/StubsGenerationTestNFApp.nfproj
+++ b/MetadataProcessor.Tests/StubsGenerationTestNFApp/StubsGenerationTestNFApp.nfproj
@@ -15,6 +15,7 @@
     <RootNamespace>StubsGenerationTestNFApp</RootNamespace>
     <AssemblyName>StubsGenerationTestNFApp</AssemblyName>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Label="nanoFramework">
     <NFMDP_GENERATE_STUBS>True</NFMDP_GENERATE_STUBS>


### PR DESCRIPTION
## Description
- Now encodes pointer parameters with valid C++ names.
- Add method with pointer parameter to test app.

## Motivation and Context
- Allows generating stubs for methods with pointer parameters.
- Related with nanoFramework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- mscorlib with new `Span<T>` and `ReadOnlySpan<T>` constructors.
- [tested against nanoclr buildId 58126].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
