### PR TITLE
Add processing of type modifiers

### DIFF
--- a/MetadataProcessor.Shared/Extensions/TypeReferenceExtensions.cs
+++ b/MetadataProcessor.Shared/Extensions/TypeReferenceExtensions.cs
@@ -74,6 +74,26 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
                 }
             }
 
+            if (type is RequiredModifierType requiredModifier)
+            {
+                StringBuilder reqModSig = new StringBuilder();
+                reqModSig.Append(requiredModifier.ElementType.TypeSignatureAsString());
+                reqModSig.Append(" modreq(");
+                reqModSig.Append(requiredModifier.ModifierType.FullName);
+                reqModSig.Append(")");
+                return reqModSig.ToString();
+            }
+
+            if (type is OptionalModifierType optionalModifier)
+            {
+                StringBuilder optModSig = new StringBuilder();
+                optModSig.Append(optionalModifier.ElementType.TypeSignatureAsString());
+                optModSig.Append(" modopt(");
+                optModSig.Append(optionalModifier.ModifierType.FullName);
+                optModSig.Append(")");
+                return optModSig.ToString();
+            }
+
             if (type.MetadataType == MetadataType.Class)
             {
                 StringBuilder classSig = new StringBuilder("CLASS ");

--- a/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
@@ -372,6 +372,30 @@ namespace nanoFramework.Tools.MetadataProcessor
                 //Debug.Fail("Gotcha!");
             }
 
+            if (typeDefinition is RequiredModifierType requiredModifier)
+            {
+                if (alsoWriteSubType)
+                {
+                    writer.WriteByte((byte)nanoSerializationType.ELEMENT_TYPE_CMOD_REQD);
+                    WriteSubTypeInfo(requiredModifier.ModifierType, writer);
+                }
+
+                WriteDataType(requiredModifier.ElementType, writer, alsoWriteSubType, expandEnumType, isTypeDefinition);
+                return;
+            }
+
+            if (typeDefinition is OptionalModifierType optionalModifier)
+            {
+                if (alsoWriteSubType)
+                {
+                    writer.WriteByte((byte)nanoSerializationType.ELEMENT_TYPE_CMOD_OPT);
+                    WriteSubTypeInfo(optionalModifier.ModifierType, writer);
+                }
+
+                WriteDataType(optionalModifier.ElementType, writer, alsoWriteSubType, expandEnumType, isTypeDefinition);
+                return;
+            }
+
             if (typeDefinition.MetadataType == MetadataType.Class)
             {
                 writer.WriteByte((byte)NanoCLRDataType.DATATYPE_CLASS);
@@ -893,7 +917,17 @@ namespace nanoFramework.Tools.MetadataProcessor
             // If there is modifier on type record of local variable, we put it before type of local variable.
             if (typeReference.IsOptionalModifier)
             {
-                writer.WriteByte(0x0); // OpTypeModifier ???
+                var optMod = typeReference as OptionalModifierType;
+                writer.WriteByte((byte)nanoSerializationType.ELEMENT_TYPE_CMOD_OPT);
+                WriteSubTypeInfo(optMod.ModifierType, writer);
+                typeReference = optMod.ElementType;
+            }
+            else if (typeReference.IsRequiredModifier)
+            {
+                var reqMod = typeReference as RequiredModifierType;
+                writer.WriteByte((byte)nanoSerializationType.ELEMENT_TYPE_CMOD_REQD);
+                WriteSubTypeInfo(reqMod.ModifierType, writer);
+                typeReference = reqMod.ElementType;
             }
 
             var byReference = typeReference as ByReferenceType;

--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -381,43 +381,79 @@ namespace nanoFramework.Tools.MetadataProcessor
                             }
                         }
 
-                        if (mr.MethodReturnType.ReturnType.IsValueType &&
-                            !mr.MethodReturnType.ReturnType.IsPrimitive)
+                        // return type modifiers - handle modifiers properly
+                        TypeReference mrReturnType = mr.ReturnType;
+
+                        // Unwrap any modifiers and add them to dependencies
+                        while (mrReturnType is RequiredModifierType mrReqMod)
                         {
-                            set.Add(mr.MethodReturnType.ReturnType.MetadataToken);
+                            set.Add(mrReqMod.ModifierType.MetadataToken);
+                            mrReturnType = mrReqMod.ElementType;
                         }
-                        else if (mr.ReturnType.IsArray)
+
+                        while (mrReturnType is OptionalModifierType mrOptMod)
                         {
-                            if (mr.ReturnType.DeclaringType != null)
+                            set.Add(mrOptMod.ModifierType.MetadataToken);
+                            mrReturnType = mrOptMod.ElementType;
+                        }
+
+                        // Handle by-reference types
+                        if (mrReturnType is ByReferenceType mrByRef)
+                        {
+                            mrReturnType = mrByRef.ElementType;
+
+                            // Check again for modifiers inside the by-reference
+                            while (mrReturnType is RequiredModifierType mrReqMod2)
                             {
-                                set.Add(mr.ReturnType.DeclaringType.MetadataToken);
+                                set.Add(mrReqMod2.ModifierType.MetadataToken);
+                                mrReturnType = mrReqMod2.ElementType;
+                            }
+
+                            while (mrReturnType is OptionalModifierType mrOptMod2)
+                            {
+                                set.Add(mrOptMod2.ModifierType.MetadataToken);
+                                mrReturnType = mrOptMod2.ElementType;
+                            }
+                        }
+
+                        // Now process the actual return type
+                        if (mrReturnType.IsValueType &&
+                            !mrReturnType.IsPrimitive)
+                        {
+                            set.Add(mrReturnType.MetadataToken);
+                        }
+                        else if (mrReturnType.IsArray)
+                        {
+                            if (mrReturnType.DeclaringType != null)
+                            {
+                                set.Add(mrReturnType.DeclaringType.MetadataToken);
                             }
                             else
                             {
-                                if (mr.ReturnType.GetElementType().FullName != "System.Void" &&
-                                     mr.ReturnType.GetElementType().FullName != "System.String" &&
-                                     mr.ReturnType.GetElementType().FullName != "System.Object" &&
-                                    !mr.ReturnType.GetElementType().IsPrimitive)
+                                if (mrReturnType.GetElementType().FullName != "System.Void" &&
+                                    mrReturnType.GetElementType().FullName != "System.String" &&
+                                    mrReturnType.GetElementType().FullName != "System.Object" &&
+                                    !mrReturnType.GetElementType().IsPrimitive)
                                 {
-                                    set.Add(mr.ReturnType.GetElementType().MetadataToken);
+                                    set.Add(mrReturnType.GetElementType().MetadataToken);
                                 }
                             }
                         }
                         else
                         {
-                            if (mr.ReturnType.MetadataType == MetadataType.ValueType)
+                            if (mrReturnType.MetadataType == MetadataType.ValueType)
                             {
-                                if (mr.ReturnType.FullName != "System.Void" &&
-                                     mr.ReturnType.FullName != "System.String" &&
-                                     mr.ReturnType.FullName != "System.Object" &&
-                                    !mr.ReturnType.IsPrimitive)
+                                if (mrReturnType.FullName != "System.Void" &&
+                                    mrReturnType.FullName != "System.String" &&
+                                    mrReturnType.FullName != "System.Object" &&
+                                    !mrReturnType.IsPrimitive)
                                 {
-                                    set.Add(mr.ReturnType.MetadataToken);
+                                    set.Add(mrReturnType.MetadataToken);
                                 }
                             }
-                            if (mr.ReturnType.MetadataType == MetadataType.Class)
+                            if (mrReturnType.MetadataType == MetadataType.Class)
                             {
-                                set.Add(mr.ReturnType.MetadataToken);
+                                set.Add(mrReturnType.MetadataToken);
                             }
                         }
 
@@ -684,37 +720,71 @@ namespace nanoFramework.Tools.MetadataProcessor
                 case TokenType.Method:
                     MethodDefinition md = _tablesContext.MethodDefinitionTable.Items.FirstOrDefault(i => i.MetadataToken == token);
 
-                    // return value
-                    if (md.ReturnType.IsValueType
-                        && !md.ReturnType.IsPrimitive)
+                    // return value - handle modifiers properly
+                    TypeReference mdReturnType = md.ReturnType;
+
+                    // Unwrap any modifiers and add them to dependencies
+                    while (mdReturnType is RequiredModifierType mdReqMod)
                     {
-                        set.Add(md.ReturnType.MetadataToken);
+                        set.Add(mdReqMod.ModifierType.MetadataToken);
+                        mdReturnType = mdReqMod.ElementType;
                     }
-                    else if (md.ReturnType.IsArray)
+
+                    while (mdReturnType is OptionalModifierType mdOptMod)
                     {
-                        if (md.ReturnType.DeclaringType != null)
+                        set.Add(mdOptMod.ModifierType.MetadataToken);
+                        mdReturnType = mdOptMod.ElementType;
+                    }
+
+                    // Handle by-reference types
+                    if (mdReturnType is ByReferenceType mdByRef)
+                    {
+                        mdReturnType = mdByRef.ElementType;
+
+                        // Check again for modifiers inside the by-reference
+                        while (mdReturnType is RequiredModifierType mdReqMod2)
                         {
-                            set.Add(md.ReturnType.DeclaringType.MetadataToken);
+                            set.Add(mdReqMod2.ModifierType.MetadataToken);
+                            mdReturnType = mdReqMod2.ElementType;
+                        }
+
+                        while (mdReturnType is OptionalModifierType mdOptMod2)
+                        {
+                            set.Add(mdOptMod2.ModifierType.MetadataToken);
+                            mdReturnType = mdOptMod2.ElementType;
+                        }
+                    }
+
+                    // Now process the actual return type
+                    if (mdReturnType.IsValueType
+                  && !mdReturnType.IsPrimitive)
+                    {
+                        set.Add(mdReturnType.MetadataToken);
+                    }
+                    else if (mdReturnType.IsArray)
+                    {
+                        if (mdReturnType.DeclaringType != null)
+                        {
+                            set.Add(mdReturnType.DeclaringType.MetadataToken);
                         }
                         else
                         {
-                            if (md.ReturnType.GetElementType().FullName != "System.Void" &&
-                                md.ReturnType.GetElementType().FullName != "System.String" &&
-                                md.ReturnType.GetElementType().FullName != "System.Object" &&
-                                !md.ReturnType.GetElementType().IsPrimitive)
+                            if (mdReturnType.GetElementType().FullName != "System.Void" &&
+                                      mdReturnType.GetElementType().FullName != "System.String" &&
+                           mdReturnType.GetElementType().FullName != "System.Object" &&
+                           !mdReturnType.GetElementType().IsPrimitive)
                             {
-                                set.Add(md.ReturnType.GetElementType().MetadataToken);
+                                set.Add(mdReturnType.GetElementType().MetadataToken);
                             }
                         }
                     }
-                    else if (!md.ReturnType.IsValueType &&
-                             !md.ReturnType.IsPrimitive &&
-                             !md.ReturnType.IsByReference &&
-                              md.ReturnType.FullName != "System.Void" &&
-                              md.ReturnType.FullName != "System.String" &&
-                              md.ReturnType.FullName != "System.Object")
+                    else if (!mdReturnType.IsValueType &&
+                           !mdReturnType.IsPrimitive &&
+               mdReturnType.FullName != "System.Void" &&
+                     mdReturnType.FullName != "System.String" &&
+                 mdReturnType.FullName != "System.Object")
                     {
-                        set.Add(md.ReturnType.MetadataToken);
+                        set.Add(mdReturnType.MetadataToken);
                     }
 
                     // generic parameters
@@ -1352,18 +1422,18 @@ namespace nanoFramework.Tools.MetadataProcessor
 
                     output.Append($"[GenericParam 0x{token.ToUInt32().ToString("X8")}]");
 
-                    if (gp.DeclaringType != null)
+                    if (gp?.DeclaringType != null)
                     {
                         output.Append(TokenToString(gp.DeclaringType.MetadataToken));
                         output.Append("::");
                     }
-                    else if (gp.DeclaringMethod != null)
+                    else if (gp?.DeclaringMethod != null)
                     {
                         output.Append(TokenToString(gp.DeclaringMethod.MetadataToken));
                         output.Append("::");
                     }
 
-                    output.Append(gp.Name);
+                    output.Append(gp?.Name);
 
                     break;
 


### PR DESCRIPTION
## Description
- WriteTypeInfo() and WriteDataType() now generate signatures for type modifiers.
- BuildDependencyList() now processes modifiers for MethodRef and MethodDef.
- TypeSignatureAsString() extension now outputs type modifiers.

## Motivation and Context
- Found this when running unit tests for `ReadOnlySpan<T>` that make use of the type modifiers.
- Related with nanoFramework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- mscorlib with new `Span<T>` and `ReadOnlySpan<T>` constructors.
- [tested against nanoclr buildId 58198].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
