### PR TITLE
Rework attributes table

### DIFF
--- a/MetadataProcessor.Shared/DumpGenerator/AttributeCustom.cs
+++ b/MetadataProcessor.Shared/DumpGenerator/AttributeCustom.cs
@@ -7,11 +7,9 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
 {
     public class AttributeCustom
     {
-        public string ReferenceId;
+        public string OwnerIndex;
 
-        public string Name;
-
-        public string TypeToken;
+        public string CtorTypeToken;
 
         public List<AttFixedArgs> FixedArgs = new List<AttFixedArgs>();
     }

--- a/MetadataProcessor.Shared/DumpGenerator/DumpTemplates.cs
+++ b/MetadataProcessor.Shared/DumpGenerator/DumpTemplates.cs
@@ -107,7 +107,7 @@ Generic Parameters{{#newline}}
 {{#newline}}
 
 {{#each Attributes}}
-Attribute: {{Name}}::[{{ReferenceId}} {{TypeToken}}]{{#newline}}
+Attribute: {{OwnerIndex}} {{CtorTypeToken}}{{#newline}}
 -------------------------------------------------------{{#newline}}
 {{#if FixedArgs}}Fixed Arguments:{{#newline}}{{#else}}{{#newline}}{{/if}}
 {{#each FixedArgs}}

--- a/MetadataProcessor.Shared/Tables/nanoAttributesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoAttributesTable.cs
@@ -1,8 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-// Original work from Oleg Rakhmatulin.
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -19,18 +17,18 @@ namespace nanoFramework.Tools.MetadataProcessor
         /// <summary>
         /// List of custom attributes in Mono.Cecil format for all internal types.
         /// </summary>
-        private IEnumerable<Tuple<CustomAttribute, ushort>> _typesAttributes;
+        private IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> _typesAttributes;
 
         /// <summary>
         /// List of custom attributes in Mono.Cecil format for all internal fields.
         /// </summary>
         /// 
-        private IEnumerable<Tuple<CustomAttribute, ushort>> _fieldsAttributes;
+        private IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> _fieldsAttributes;
 
         /// <summary>
         /// List of custom attributes in Mono.Cecil format for all internal methods.
         /// </summary>
-        private IEnumerable<Tuple<CustomAttribute, ushort>> _methodsAttributes;
+        private IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> _methodsAttributes;
 
         /// <summary>
         /// Assembly tables context - contains all tables used for building target assembly.
@@ -38,6 +36,16 @@ namespace nanoFramework.Tools.MetadataProcessor
         private readonly nanoTablesContext _context;
 
         public NanoClrTable TableIndex => NanoClrTable.TBL_Attributes;
+
+        /// <summary>
+        /// Gets all attributes (types, fields, and methods combined).
+        /// </summary>
+        public IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> GetAllAttributes()
+        {
+            return _typesAttributes
+                .Concat(_fieldsAttributes)
+                .Concat(_methodsAttributes);
+        }
 
         /// <summary>
         /// Creates new instance of <see cref="nanoAttributesTable"/> object.
@@ -55,9 +63,9 @@ namespace nanoFramework.Tools.MetadataProcessor
         /// Assembly tables context - contains all tables used for building target assembly.
         /// </param>
         public nanoAttributesTable(
-            IEnumerable<Tuple<CustomAttribute, ushort>> typesAttributes,
-            IEnumerable<Tuple<CustomAttribute, ushort>> fieldsAttributes,
-            IEnumerable<Tuple<CustomAttribute, ushort>> methodsAttributes,
+            IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> typesAttributes,
+            IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> fieldsAttributes,
+            IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> methodsAttributes,
             nanoTablesContext context)
         {
             _typesAttributes = typesAttributes.ToList();
@@ -71,27 +79,61 @@ namespace nanoFramework.Tools.MetadataProcessor
         public void Write(
             nanoBinaryWriter writer)
         {
-            WriteAttributes(writer, 0x0004, _typesAttributes);
-            WriteAttributes(writer, 0x0005, _fieldsAttributes);
-            WriteAttributes(writer, 0x0006, _methodsAttributes);
+            WriteAttributes(
+                writer,
+                (ushort)NanoClrTable.TBL_TypeDef,
+                _typesAttributes);
+
+            WriteAttributes(
+                writer,
+                (ushort)NanoClrTable.TBL_FieldDef,
+                _fieldsAttributes);
+
+            WriteAttributes(
+                writer,
+                (ushort)NanoClrTable.TBL_MethodDef,
+                _methodsAttributes);
         }
 
         private void WriteAttributes(
             nanoBinaryWriter writer,
             ushort tableNumber,
-            IEnumerable<Tuple<CustomAttribute, ushort>> attributes)
+            IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> attributes)
         {
-            foreach (var item in attributes)
+            foreach (Tuple<CustomAttribute, ICustomAttributeProvider> item in attributes)
             {
-                var attribute = item.Item1;
-                var targetIdentifier = item.Item2;
+                CustomAttribute attribute = item.Item1;
+                ICustomAttributeProvider owner = item.Item2;
 
                 writer.WriteUInt16(tableNumber);
+
+                // Get the reference ID based on the owner type
+                ushort targetIdentifier = GetOwnerReferenceId(owner);
                 writer.WriteUInt16(targetIdentifier);
 
                 writer.WriteUInt16(_context.GetMethodReferenceId(attribute.Constructor));
                 writer.WriteUInt16(_context.SignaturesTable.GetOrCreateSignatureId(attribute));
             }
+        }
+
+        private ushort GetOwnerReferenceId(ICustomAttributeProvider owner)
+        {
+            ushort referenceId = 0xFFFF;
+
+            if (owner is TypeDefinition typeDef)
+            {
+                _context.TypeDefinitionTable.TryGetTypeReferenceId(typeDef, out referenceId);
+            }
+            else if (owner is MethodDefinition methodDef)
+            {
+                _context.MethodDefinitionTable.TryGetMethodReferenceId(methodDef, out referenceId);
+            }
+            else if (owner is FieldDefinition fieldDef)
+            {
+                _context.FieldsTable.TryGetFieldDefinitionId(fieldDef, false, out referenceId);
+            }
+
+            return referenceId;
         }
 
         /// <summary>
@@ -100,44 +142,41 @@ namespace nanoFramework.Tools.MetadataProcessor
         public void RemoveUnusedItems(HashSet<MetadataToken> set)
         {
             // build a collection of the current items that are present in the used items set
-            List<Tuple<CustomAttribute, ushort>> usedItems = new List<Tuple<CustomAttribute, ushort>>();
+            List<Tuple<CustomAttribute, ICustomAttributeProvider>> usedItems = new List<Tuple<CustomAttribute, ICustomAttributeProvider>>();
 
             // types attributes
-            foreach (var item in _typesAttributes
-                                    .Where(item => set.Contains(((IMetadataTokenProvider)item.Item1.Constructor).MetadataToken)))
+            foreach (var item in _typesAttributes.Where(item => set.Contains(item.Item1.AttributeType.MetadataToken)
+                                                                || set.Contains(((IMetadataTokenProvider)item.Item1.Constructor).MetadataToken)))
             {
                 usedItems.Add(item);
             }
 
             // re-create the items dictionary with the used items only
-            _typesAttributes = usedItems
-            .Select(a => new Tuple<CustomAttribute, ushort>(a.Item1, a.Item2));
+            _typesAttributes = usedItems.Select(a => new Tuple<CustomAttribute, ICustomAttributeProvider>(a.Item1, a.Item2));
 
             // fields attributes
-            usedItems = new List<Tuple<CustomAttribute, ushort>>();
+            usedItems = new List<Tuple<CustomAttribute, ICustomAttributeProvider>>();
 
-            foreach (var item in _fieldsAttributes
-                                    .Where(item => set.Contains(((IMetadataTokenProvider)item.Item1.Constructor).MetadataToken)))
+            foreach (var item in _fieldsAttributes.Where(item => set.Contains(item.Item1.AttributeType.MetadataToken)
+                                                                 || set.Contains(((IMetadataTokenProvider)item.Item1.Constructor).MetadataToken)))
             {
                 usedItems.Add(item);
             }
 
             // re-create the items dictionary with the used items only
-            _fieldsAttributes = usedItems
-            .Select(a => new Tuple<CustomAttribute, ushort>(a.Item1, a.Item2));
+            _fieldsAttributes = usedItems.Select(a => new Tuple<CustomAttribute, ICustomAttributeProvider>(a.Item1, a.Item2));
 
             // methods attributes
-            usedItems = new List<Tuple<CustomAttribute, ushort>>();
+            usedItems = new List<Tuple<CustomAttribute, ICustomAttributeProvider>>();
 
-            foreach (var item in _methodsAttributes
-                                    .Where(item => set.Contains(((IMetadataTokenProvider)item.Item1.Constructor).MetadataToken)))
+            foreach (var item in _methodsAttributes.Where(item => set.Contains(item.Item1.AttributeType.MetadataToken)
+                                                                  || set.Contains(((IMetadataTokenProvider)item.Item1.Constructor).MetadataToken)))
             {
                 usedItems.Add(item);
             }
 
             // re-create the items dictionary with the used items only
-            _methodsAttributes = usedItems
-            .Select(a => new Tuple<CustomAttribute, ushort>(a.Item1, a.Item2));
+            _methodsAttributes = usedItems.Select(a => new Tuple<CustomAttribute, ICustomAttributeProvider>(a.Item1, a.Item2));
         }
     }
 }

--- a/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
@@ -523,7 +523,7 @@ namespace nanoFramework.Tools.MetadataProcessor
         public static List<string> ClassNamesToExclude { get; private set; }
         public bool MinimizeComplete { get; internal set; } = false;
 
-        private IEnumerable<Tuple<CustomAttribute, ushort>> GetAttributes(
+        private IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> GetAttributes(
             IEnumerable<ICustomAttributeProvider> types,
             bool applyAttributesCompression)
         {
@@ -533,13 +533,13 @@ namespace nanoFramework.Tools.MetadataProcessor
                     (item, index) => item.CustomAttributes
                         .Where(attr => !IsAttribute(attr.AttributeType))
                         .OrderByDescending(attr => attr.AttributeType.FullName)
-                        .Select(attr => new Tuple<CustomAttribute, ushort>(attr, (ushort)index)));
+                        .Select(attr => new Tuple<CustomAttribute, ICustomAttributeProvider>(attr, item)));
 
             }
             return types.SelectMany(
                 (item, index) => item.CustomAttributes
                     .Where(attr => !IsAttribute(attr.AttributeType))
-                    .Select(attr => new Tuple<CustomAttribute, ushort>(attr, (ushort)index)));
+                    .Select(attr => new Tuple<CustomAttribute, ICustomAttributeProvider>(attr, item)));
         }
 
         private bool IsAttribute(

--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -1153,7 +1153,7 @@ namespace nanoFramework.Tools.MetadataProcessor
 
                                 if (opToken.TokenType == TokenType.TypeSpec)
                                 {
-                                    // Cecil.Mono has a bug providing TypeSpecs Metadata tokens generic parameters variables,
+                                    // Cecil.Mono has a bug providing TypeSpecs Metadata tokens generic parameters,
                                     // so we need to check against our internal table and build one from it
                                     if (_tablesContext.TypeSpecificationsTable.TryGetTypeReferenceId(
                                         opType,

--- a/MetadataProcessor.Shared/nanoDumperGenerator.cs
+++ b/MetadataProcessor.Shared/nanoDumperGenerator.cs
@@ -84,54 +84,56 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
 
         private void DumpCustomAttributes(DumpAllTable dumpTable)
         {
-            foreach (var a in _tablesContext.TypeDefinitionTable.Items.Where(td => td.HasCustomAttributes))
+            // Loop through all attributes from the AttributesTable
+            foreach (var attributeTuple in _tablesContext.AttributesTable.GetAllAttributes())
             {
-                foreach (var ma in a.Methods)
+                CustomAttribute customAttr = attributeTuple.Item1;
+                ICustomAttributeProvider owner = attributeTuple.Item2;
+
+                string ownerDescription;
+                ushort ownerIndex;
+                NanoClrTable ownerTable;
+
+                // Determine the owner type and get its reference ID
+                if (owner is TypeDefinition typeDef)
                 {
-                    if (ma.HasCustomAttributes)
+                    _tablesContext.TypeDefinitionTable.TryGetTypeReferenceId(typeDef, out ownerIndex);
+                    ownerTable = NanoClrTable.TBL_TypeDef;
+                    ownerDescription = $"{typeDef.FullName} [{new nanoMetadataToken(ownerTable, ownerIndex)}] /*{typeDef.MetadataToken.ToInt32():X8}*/";
+                }
+                else if (owner is MethodDefinition methodDef)
+                {
+                    _tablesContext.MethodDefinitionTable.TryGetMethodReferenceId(methodDef, out ownerIndex);
+                    ownerTable = NanoClrTable.TBL_MethodDef;
+                    ownerDescription = $"{methodDef.DeclaringType.FullName}::{methodDef.Name} [{new nanoMetadataToken(ownerTable, ownerIndex)}] /*{methodDef.MetadataToken.ToInt32():X8}*/";
+                }
+                else if (owner is FieldDefinition fieldDef)
+                {
+                    _tablesContext.FieldsTable.TryGetFieldDefinitionId(fieldDef, false, out ownerIndex);
+                    ownerTable = NanoClrTable.TBL_FieldDef;
+                    ownerDescription = $"{fieldDef.DeclaringType.FullName}::{fieldDef.Name} [{new nanoMetadataToken(ownerTable, ownerIndex)}] /*{fieldDef.MetadataToken.ToInt32():X8}*/";
+                }
+                else
+                {
+                    // Unknown owner type, skip
+                    continue;
+                }
+
+                var attribute = new AttributeCustom()
+                {
+                    OwnerIndex = ownerDescription,
+                    CtorTypeToken = $"{customAttr.Constructor.DeclaringType.FullName}::.ctor /*{customAttr.Constructor.MetadataToken.ToInt32():X8}*/"
+                };
+
+                if (customAttr.HasConstructorArguments)
+                {
+                    foreach (var value in customAttr.ConstructorArguments)
                     {
-                        var attribute = new AttributeCustom()
-                        {
-                            Name = a.Module.Assembly.Name.Name,
-                            ReferenceId = ma.MetadataToken.ToInt32().ToString("X8"),
-                            TypeToken = ma.CustomAttributes[0].Constructor.MetadataToken.ToInt32().ToString("X8")
-                        };
-
-                        if (ma.CustomAttributes[0].HasConstructorArguments)
-                        {
-                            foreach (var value in ma.CustomAttributes[0].ConstructorArguments)
-                            {
-                                attribute.FixedArgs.AddRange(BuildFixedArgsAttribute(value));
-                            }
-                        }
-
-                        dumpTable.Attributes.Add(attribute);
+                        attribute.FixedArgs.AddRange(BuildFixedArgsAttribute(value));
                     }
                 }
 
-                foreach (var fa in a.Fields)
-                {
-                    if (fa.HasCustomAttributes)
-                    {
-                        var attribute = new AttributeCustom()
-                        {
-                            Name = a.Module.Assembly.Name.Name,
-                            ReferenceId = fa.MetadataToken.ToInt32().ToString("X8"),
-                            TypeToken = fa.CustomAttributes[0].Constructor.MetadataToken.ToInt32().ToString("X8")
-                        };
-
-                        if (!nanoTablesContext.IgnoringAttributes.Contains(fa.CustomAttributes[0].AttributeType.FullName)
-                            && fa.CustomAttributes[0].HasConstructorArguments)
-                        {
-                            foreach (CustomAttributeArgument value in fa.CustomAttributes[0].ConstructorArguments)
-                            {
-                                attribute.FixedArgs.AddRange(BuildFixedArgsAttribute(value));
-                            }
-                        }
-
-                        dumpTable.Attributes.Add(attribute);
-                    }
-                }
+                dumpTable.Attributes.Add(attribute);
             }
         }
 
@@ -164,11 +166,11 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     break;
 
                 case nanoSerializationType.ELEMENT_TYPE_STRING:
-                    newArg.Text = (string)value.Value;
+                    newArg.Text = value.Value == null ? "<null>" : (string)value.Value;
                     break;
 
                 case nanoSerializationType.ELEMENT_TYPE_OBJECT:
-                    newArg.Text = (string)value.Value;
+                    newArg.Text = value.Value == null ? "<null>" : value.Value.ToString();
                     break;
 
                 case nanoSerializationType.ELEMENT_TYPE_I1:
@@ -204,7 +206,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     break;
 
                 default:
-                    newArg.Text = value.Value.ToString();
+                    newArg.Text = value.Value == null ? "<null>" : value.Value.ToString();
                     break;
             }
 
@@ -599,6 +601,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                 typeRef.ReferenceId = $"[{new nanoMetadataToken(t.MetadataToken, referenceId)}] /*{realToken}*/";
 
                 // list member refs               
+
                 foreach (var m in _tablesContext.MethodReferencesTable.Items.Where(mr => mr.DeclaringType == t))
                 {
                     var memberRef = new MemberRef()

--- a/MetadataProcessor.Tests/Core/Tables/nanoAttributesTableTests.cs
+++ b/MetadataProcessor.Tests/Core/Tables/nanoAttributesTableTests.cs
@@ -18,9 +18,9 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
         [TestMethod]
         public void ConstructorTest()
         {
-            var typesAttributes = new Tuple<CustomAttribute, ushort>[0];
-            var fieldsAttributes = new Tuple<CustomAttribute, ushort>[0];
-            var methodsAttributes = new Tuple<CustomAttribute, ushort>[0];
+            var typesAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[0];
+            var fieldsAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[0];
+            var methodsAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[0];
             var context = TestObjectHelper.GetTestNFAppNanoTablesContext();
 
             // test
@@ -42,12 +42,12 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
             var referencedMetadataTokens = new HashSet<MetadataToken>();
             referencedMetadataTokens.Add(customAttribute1.Constructor.MetadataToken);
 
-            var tuple0 = new Tuple<CustomAttribute, ushort>(customAttribute0, 1);
-            var tuple1 = new Tuple<CustomAttribute, ushort>(customAttribute1, 2);
+            var tuple0 = new Tuple<CustomAttribute, ICustomAttributeProvider>(customAttribute0, testClassTypeDefinition);
+            var tuple1 = new Tuple<CustomAttribute, ICustomAttributeProvider>(customAttribute1, testClassTypeDefinition);
 
-            var typesAttributes = new Tuple<CustomAttribute, ushort>[] { tuple0, tuple1 };
-            var fieldsAttributes = new Tuple<CustomAttribute, ushort>[0];
-            var methodsAttributes = new Tuple<CustomAttribute, ushort>[0];
+            var typesAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[] { tuple0, tuple1 };
+            var fieldsAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[0];
+            var methodsAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[0];
             var context = TestObjectHelper.GetTestNFAppNanoTablesContext();
 
             var iut = new nanoAttributesTable(typesAttributes, fieldsAttributes, methodsAttributes, context);
@@ -61,13 +61,17 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
                 iut.Write(writer);
             });
 
+            // Get the expected reference ID for the type definition
+            ushort expectedTypeRefId = 0;
+            context.TypeDefinitionTable.TryGetTypeReferenceId(testClassTypeDefinition, out expectedTypeRefId);
+
             var methodReferenceId = context.GetMethodReferenceId(customAttribute1.Constructor);
             var signatureId = context.SignaturesTable.GetOrCreateSignatureId(customAttribute1);
             CollectionAssert.AreEqual(
                 new byte[]
                 {
                     0x04, 0,
-                    (byte)(tuple1.Item2 & 0xff), (byte)(tuple1.Item2 >> 8),
+                    (byte)(expectedTypeRefId & 0xff), (byte)(expectedTypeRefId >> 8),
                     (byte)(methodReferenceId & 0xff), (byte)(methodReferenceId >> 8),
                     (byte)(signatureId & 0xff), (byte)(signatureId >> 8),
                 },
@@ -80,7 +84,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
         {
             var nanoTablesContext = TestObjectHelper.GetTestNFAppNanoTablesContext();
             var typeDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllTypeDefinition(nanoTablesContext.AssemblyDefinition);
-
             var dummyFieldDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllDummyFieldDefinition(typeDefinition);
 
             Assert.IsTrue(dummyFieldDefinition.CustomAttributes.Count > 1);
@@ -90,12 +93,12 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
             var referencedMetadataTokens = new HashSet<MetadataToken>();
             referencedMetadataTokens.Add(customAttribute1.Constructor.MetadataToken);
 
-            var tuple0 = new Tuple<CustomAttribute, ushort>(customAttribute0, 1);
-            var tuple1 = new Tuple<CustomAttribute, ushort>(customAttribute1, 2);
+            var tuple0 = new Tuple<CustomAttribute, ICustomAttributeProvider>(customAttribute0, dummyFieldDefinition);
+            var tuple1 = new Tuple<CustomAttribute, ICustomAttributeProvider>(customAttribute1, dummyFieldDefinition);
 
-            var typesAttributes = new Tuple<CustomAttribute, ushort>[0];
-            var fieldsAttributes = new Tuple<CustomAttribute, ushort>[] { tuple0, tuple1 };
-            var methodsAttributes = new Tuple<CustomAttribute, ushort>[0];
+            var typesAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[0];
+            var fieldsAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[] { tuple0, tuple1 };
+            var methodsAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[0];
             var context = TestObjectHelper.GetTestNFAppNanoTablesContext();
 
             var iut = new nanoAttributesTable(typesAttributes, fieldsAttributes, methodsAttributes, context);
@@ -109,13 +112,17 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
                 iut.Write(writer);
             });
 
+            // Get the expected reference ID for the field definition
+            ushort expectedFieldRefId = 0;
+            context.FieldsTable.TryGetFieldDefinitionId(dummyFieldDefinition, false, out expectedFieldRefId);
+
             var methodReferenceId = context.GetMethodReferenceId(customAttribute1.Constructor);
             var signatureId = context.SignaturesTable.GetOrCreateSignatureId(customAttribute1);
             CollectionAssert.AreEqual(
                 new byte[]
                 {
                     0x05, 0,
-                    (byte)(tuple1.Item2 & 0xff), (byte)(tuple1.Item2 >> 8),
+                    (byte)(expectedFieldRefId & 0xff), (byte)(expectedFieldRefId >> 8),
                     (byte)(methodReferenceId & 0xff), (byte)(methodReferenceId >> 8),
                     (byte)(signatureId & 0xff), (byte)(signatureId >> 8),
                 },
@@ -136,12 +143,12 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
             var referencedMetadataTokens = new HashSet<MetadataToken>();
             referencedMetadataTokens.Add(customAttribute1.Constructor.MetadataToken);
 
-            var tuple0 = new Tuple<CustomAttribute, ushort>(customAttribute0, 1);
-            var tuple1 = new Tuple<CustomAttribute, ushort>(customAttribute1, 2);
+            var tuple0 = new Tuple<CustomAttribute, ICustomAttributeProvider>(customAttribute0, methodDefinition);
+            var tuple1 = new Tuple<CustomAttribute, ICustomAttributeProvider>(customAttribute1, methodDefinition);
 
-            var typesAttributes = new Tuple<CustomAttribute, ushort>[0];
-            var fieldsAttributes = new Tuple<CustomAttribute, ushort>[0];
-            var methodsAttributes = new Tuple<CustomAttribute, ushort>[] { tuple0, tuple1 };
+            var typesAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[0];
+            var fieldsAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[0];
+            var methodsAttributes = new Tuple<CustomAttribute, ICustomAttributeProvider>[] { tuple0, tuple1 };
             var context = TestObjectHelper.GetTestNFAppNanoTablesContext();
 
             var iut = new nanoAttributesTable(typesAttributes, fieldsAttributes, methodsAttributes, context);
@@ -155,13 +162,17 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
                 iut.Write(writer);
             });
 
+            // Get the expected reference ID for the method definition
+            ushort expectedMethodRefId = 0;
+            context.MethodDefinitionTable.TryGetMethodReferenceId(methodDefinition, out expectedMethodRefId);
+
             var methodReferenceId = context.GetMethodReferenceId(customAttribute1.Constructor);
             var signatureId = context.SignaturesTable.GetOrCreateSignatureId(customAttribute1);
             CollectionAssert.AreEqual(
                 new byte[]
                 {
                     0x06, 0,
-                    (byte)(tuple1.Item2 & 0xff), (byte)(tuple1.Item2 >> 8),
+                    (byte)(expectedMethodRefId & 0xff), (byte)(expectedMethodRefId >> 8),
                     (byte)(methodReferenceId & 0xff), (byte)(methodReferenceId >> 8),
                     (byte)(signatureId & 0xff), (byte)(signatureId >> 8),
                 },

--- a/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
+++ b/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
@@ -15,6 +15,7 @@
     <RootNamespace>TestNFApp</RootNamespace>
     <AssemblyName>TestNFApp</AssemblyName>
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
+    <LangVersion>13.0</LangVersion>
   </PropertyGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.props" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.props')" />
   <ItemGroup>


### PR DESCRIPTION
## Description
- Attributes table now stores ICustomAttributeProvider instead of fixed index.
- Attribute owner now is a proper index into the owner type table.
- Improve dump classes to make them simple.
- Update dump template accordingly.
- Complete rewrite of DumpCustomAttributes(), now using the table items instead of crawling again the types, fields and methods.
- Output of null objects now is visible in dump file.
- Update attributes unit tests accordingly.

## Motivation and Context
- Fixes issues with attributes storing fixed indexes instead of types in table, following processing, minimization and shuffling was causing issues.
- Related with nanoFramework/Home#782

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- [tested against nanoclr buildId 58308].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
