### PR TITLE
Fix issues with TypeSpec tokens

### DIFF
--- a/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
+++ b/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
@@ -178,11 +178,14 @@ namespace nanoFramework.Tools.MetadataProcessor
     {
         public TypeSpec(nanoTablesContext context, TypeReference item)
         {
-            context.TypeSpecificationsTable.TryGetTypeReferenceId(item, out ushort nanoToken);
+            // sanity check for bug in Mono.Cecil where TypeSpecification instances may show with RID = 0
+            if (!context.TypeSpecificationsTable.TryGetTypeReferenceId(item, out ushort nanoToken))
+            {
+                // OK to return here
+                return;
+            }
 
-            // assume that real token index is the same as ours
-            // need to add one because ours is 0 indexed
-            var clrToken = new MetadataToken(TokenType.TypeSpec, nanoToken + 1);
+            var clrToken = new MetadataToken(TokenType.TypeSpec, nanoToken);
 
             Token = new Token(clrToken, NanoClrTable.TBL_TypeSpec.ToNanoTokenType() | nanoToken);
 

--- a/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
@@ -47,7 +47,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                     throw new ArgumentNullException(nameof(y));
                 }
 
-                return string.Equals(x.MetadataToken, y.MetadataToken);
+                return x.MetadataToken.Equals(y.MetadataToken);
             }
 
             /// <inheritdoc/>
@@ -116,6 +116,15 @@ namespace nanoFramework.Tools.MetadataProcessor
             TypeReference typeReference,
             out ushort referenceId)
         {
+            // sanity check for bug in Mono.Cecil where TypeSpecification instances may show with RID = 0
+            if (typeReference is TypeSpecification && typeReference.MetadataToken.RID == 0)
+            {
+                referenceId = 0;
+
+                // don't add this invalid entry
+                return false;
+            }
+
             if (_idByTypeSpecifications.TryGetValue(typeReference, out referenceId))
             {
                 referenceId = (ushort)Array.IndexOf(_idByTypeSpecifications.Values.ToArray(), referenceId);
@@ -125,6 +134,7 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             return false;
         }
+
         public TypeReference TryGetTypeSpecification(MetadataToken token)
         {
             // try a direct match on the TypeReference itself
@@ -454,6 +464,13 @@ namespace nanoFramework.Tools.MetadataProcessor
             TypeReference tr,
             ushort sigId)
         {
+            // sanity check for bug in Mono.Cecil where TypeSpecification instances may show with RID = 0
+            if (tr is TypeSpecification && tr.MetadataToken.RID == 0)
+            {
+                // don't add this invalid entry
+                return;
+            }
+
             if (!_idByTypeSpecifications.ContainsKey(tr)
                 && !tr.IsToExclude())
             {

--- a/MetadataProcessor.Shared/Utility/TypeReferenceEqualityComparer.cs
+++ b/MetadataProcessor.Shared/Utility/TypeReferenceEqualityComparer.cs
@@ -74,10 +74,15 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             if (obj is TypeSpecification)
             {
-                ushort xSignatureId = _context.SignaturesTable.GetOrCreateSignatureId(obj);
+                ushort signatureId = _context.SignaturesTable.GetOrCreateSignatureId(obj);
 
-                // provide an hash code based on the TypeSpec signature 
-                return xSignatureId;
+                // Combine signature ID with metadata token hash for better distribution
+                // Use unchecked to allow overflow and maintain consistent hash code behavior
+                int hash = 17;
+                hash = unchecked(hash * 31 + signatureId);
+                hash = unchecked(hash * 31 + obj.MetadataToken.GetHashCode());
+
+                return hash;
             }
             else if (obj is GenericParameter genericParam)
             {

--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -914,10 +914,6 @@ namespace nanoFramework.Tools.MetadataProcessor
                                     // add the metadata token for the element type
                                     set.Add(v.VariableType.GetElementType().MetadataToken);
                                 }
-                                else
-                                {
-                                    Debug.Fail($"Couldn't find a TypeSpec entry for {v.VariableType}");
-                                }
                             }
                             else if (v.VariableType.IsValueType
                                      && !v.VariableType.IsPrimitive)

--- a/MetadataProcessor.Shared/nanoDumperGenerator.cs
+++ b/MetadataProcessor.Shared/nanoDumperGenerator.cs
@@ -654,6 +654,8 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
             // get real token for the TypeSpec
             string realToken = string.Empty;
 
+            // DEVELOPER NOTE: this call should be checked for success
+            // it's OK to skip this as this is "only" for dumping purposes
             _tablesContext.TypeSpecificationsTable.TryGetTypeReferenceId(typeReference, out ushort index);
 
             TypeSpec typeSpec = new TypeSpec();
@@ -865,6 +867,8 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                         sig.Append($"class {l.VariableType.FullName}");
                     }
 
+                    // DEVELOPER NOTE: this call should be checked for success
+                    // it's OK to skip this as this is "only" for dumping purposes
                     _tablesContext.TypeSpecificationsTable.TryGetTypeReferenceId(l.VariableType as TypeSpecification, out ushort referenceId);
 
                     sig.Append($"[{new nanoMetadataToken(NanoClrTable.TBL_TypeSpec, referenceId)}] /*{l.VariableType.GetElementType().MetadataToken.ToInt32().ToString("X8")}*/");


### PR DESCRIPTION
## Description
- TypeSpecificationEqualityComparer now compares metadata tokens.
- GetHashCode of TypeReferenceEqualityComparer now computes better hash code with signarture and metadata token.
- Try APIs in TypeSpec table now validate for 0 RID in metadata token and fail on such.
- Remove debug fail in BuildDependencies for unexisting TypeSpec (happening with RID = 0).
- Add check (or notes) on callers that may fail in dumper and pdbx file helper.

## Motivation and Context
- This is workaround for a bug in Mono.Cecil that causes invalid TypeSpec tokens to have a RID = 0. See jbevain/cecil#953. When that is fixed we should revisit this.
- After the this was merged, further testing uncover an edge case which has been fixed with #225.
- Related with nanoFramework/Home#782

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests, I2C unit tests (with `Span<byte>` and Sys.Collections unit tests with `List<T>`.
- [tested against nanoclr buildId 58382].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
