### PR TITLE
Fix state of console to allow output after generating skeleton files

### DIFF
--- a/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
+++ b/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
@@ -298,13 +298,16 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
             FileStream logOutputStream = null;
             StreamWriter logWriter = null;
             string logFile = "";
+            TextWriter originalConsoleOut = null;
 
             try
             {
                 if (Verbose)
                 {
-                    logFile = Path.ChangeExtension(fileName, "log.txt");
+                    // Save original
+                    originalConsoleOut = Console.Out;
 
+                    logFile = Path.ChangeExtension(fileName, "log.txt");
                     logOutputStream = new FileStream(logFile, FileMode.OpenOrCreate, FileAccess.Write);
                     logWriter = new StreamWriter(logOutputStream);
                     Console.SetOut(logWriter);
@@ -401,6 +404,12 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                 {
                     logWriter?.Close();
                     logOutputStream?.Close();
+
+                    if (originalConsoleOut != null)
+                    {
+                        // Restore original
+                        Console.SetOut(originalConsoleOut);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Description
- State of Console.Out is now saved before redirecting and then restored after logging is complete.

## Motivation and Context
- Found when updating libraries. The build would fail with an exception after skeleton files where generated.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- MDP unit tests.
- [tested against nanoclr buildId 58382].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
