### PR TITLE
Update native methods CRC calculation

### DIFF
--- a/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
+++ b/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
@@ -3,7 +3,6 @@
 
 // Original work from Oleg Rakhmatulin.
 
-using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -57,21 +56,22 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         public void UpdateCrc(MethodDefinition method)
         {
-            var type = method.DeclaringType;
+            TypeDefinition type = method.DeclaringType;
 
+            // Always update CRC for every method to make it position-dependent.
+            // This ensures any structural change (adding methods, reordering, etc.) will change the CRC.
             if (type.IncludeInStub() &&
                 (method.RVA == 0 && !method.IsAbstract))
             {
-                _currentCrc = Crc32.Compute(_name, CurrentCrc);
-                _currentCrc = Crc32.Compute(Encoding.ASCII.GetBytes(GetSafeClassName(type)), CurrentCrc);
-                _currentCrc = Crc32.Compute(Encoding.ASCII.GetBytes(GetSafeMethodName(method)), CurrentCrc);
+                _currentCrc = Crc32.Compute(_name, _currentCrc);
+                _currentCrc = Crc32.Compute(Encoding.ASCII.GetBytes(GetSafeClassName(type)), _currentCrc);
+                _currentCrc = Crc32.Compute(Encoding.ASCII.GetBytes(GetSafeMethodName(method)), _currentCrc);
 
                 _methodsWithNativeImplementation++;
             }
-            else
-            {
-                _currentCrc = Crc32.Compute(_null, CurrentCrc);
-            }
+
+            // Always add nullptr marker to make CRC position-dependent
+            _currentCrc = Crc32.Compute(_null, _currentCrc);
         }
 
         internal static string GetSafeClassName(TypeDefinition type)
@@ -191,7 +191,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                     // check if it's generic
                     return "DATATYPE_GENERICTYPE";
                 }
-                else if(parameterType.IsPointer)
+                else if (parameterType.IsPointer)
                 {
                     if (nanoSignaturesTable.PrimitiveTypes.TryGetValue(parameterType.GetElementType().FullName, out myType))
                     {

--- a/MetadataProcessor.Tests/Core/Utility/NativeMethodsCrcTests.cs
+++ b/MetadataProcessor.Tests/Core/Utility/NativeMethodsCrcTests.cs
@@ -157,19 +157,19 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             // test
             iut.UpdateCrc(externMethodDefinition);
 
-            Assert.AreEqual((uint)519713657, iut.CurrentCrc);
+            Assert.AreEqual((uint)786692857, iut.CurrentCrc);
 
             // test
             iut.UpdateCrc(externMethodDefinition);
 
 
-            Assert.AreEqual((uint)1574868855, iut.CurrentCrc);
+            Assert.AreEqual((uint)3989161217, iut.CurrentCrc);
 
 
             // test
             iut.UpdateCrc(nonExternMethodDefinition);
 
-            Assert.AreEqual((uint)882012044, iut.CurrentCrc);
+            Assert.AreEqual((uint)1852731366, iut.CurrentCrc);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
- Now always adding the nullptr sentinel to have every method position dependent.
- Update unit test accordingly.

## Motivation and Context
- Need to improve the checksum calculation to detect changes in order of the methods and adding new methods that don't have native implementation. In particular, the latter was causing issues with assemblies having their declaration changes and this going unnoticed.
- Documentation has been updated accordingly: nanoframework/nanoframework.github.io@7b4b709

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [x] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
