### PR TITLE
Fix minimize failing for generic interface TypeSpecs with no member refs

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
@@ -317,6 +317,18 @@ namespace nanoFramework.Tools.MetadataProcessor
                     }
                 }
 
+                // Interface implementations on the type
+                if (td.HasInterfaces)
+                {
+                    foreach (InterfaceImplementation iface in td.Interfaces)
+                    {
+                        if (iface.InterfaceType is TypeSpecification)
+                        {
+                            ExpandNestedTypeSpecs(iface.InterfaceType);
+                        }
+                    }
+                }
+
                 foreach (MethodDefinition m in td.Methods.Where(m => m.HasBody))
                 {
                     foreach (VariableDefinition variable in m.Body.Variables)
@@ -606,6 +618,20 @@ namespace nanoFramework.Tools.MetadataProcessor
                                     hasMemberReferences = true;
                                     break;
                                 }
+                            }
+                        }
+                    }
+
+                    // Check if used as an interface type on any TypeDefinition
+                    if (!hasMemberReferences)
+                    {
+                        string genericInstanceFullName = genericInstanceType.FullName;
+                        foreach (TypeDefinition td in _context.TypeDefinitionTable.Items)
+                        {
+                            if (td.HasInterfaces && td.Interfaces.Any(i => i.InterfaceType.FullName == genericInstanceFullName))
+                            {
+                                hasMemberReferences = true;
+                                break;
                             }
                         }
                     }

--- a/MetadataProcessor.Shared/nanoDumperGenerator.cs
+++ b/MetadataProcessor.Shared/nanoDumperGenerator.cs
@@ -799,7 +799,14 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                     }
                 }
 
-                Debug.Assert(typeSpec.MemberReferences.Count > 0, $"Couldn't find any MethodRef for TypeSpec[{typeReference}] {typeReference.FullName}");
+                if (typeSpec.MemberReferences.Count == 0)
+                {
+                    // A TypeSpec used only as an interface implementation has no member references — that is valid.
+                    bool usedAsInterface = _tablesContext.TypeDefinitionTable.Items
+                        .Any(td => td.Interfaces.Any(i => i.InterfaceType.FullName == typeReference.FullName));
+
+                    Debug.Assert(usedAsInterface, $"Couldn't find any MethodRef for TypeSpec[{typeReference}] {typeReference.FullName}");
+                }
             }
 
             dumpTable.TypeSpecifications.Add(typeSpec);

--- a/MetadataProcessor.Tests/TestNFApp/GenericInterfaceTypeSpecTests.cs
+++ b/MetadataProcessor.Tests/TestNFApp/GenericInterfaceTypeSpecTests.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Regression test for: TypeSpec entries used only as interface implementations
+// (no member references) being incorrectly removed during assembly minimization,
+// causing "Can't find entry in type reference table" when writing interface
+// signatures in the second pass.
+
+using System;
+using System.Collections;
+
+namespace TestNFApp
+{
+    // A struct defined in this assembly, used as a generic type argument.
+    // Analogous to KeyValuePair<TKey,TValue> in System.Collections.
+    public struct Pair<TKey, TValue>
+    {
+        public TKey Key;
+        public TValue Value;
+
+        public Pair(TKey key, TValue value)
+        {
+            Key = key;
+            Value = value;
+        }
+    }
+
+    // An interface that inherits the non-generic System.Collections.IEnumerable.
+    // The C# compiler adds System.Collections.IEnumerable to InterfaceImpls —
+    // a non-generic TypeSpec with no member references in this assembly.
+    public interface IPairCollection<TKey, TValue> : IEnumerable
+    {
+        int Count { get; }
+        Pair<TKey, TValue> GetAt(int index);
+    }
+
+    // A concrete implementation — exercises the TypeSpec in the interface list.
+    public class PairCollection<TKey, TValue> : IPairCollection<TKey, TValue>
+    {
+        private Pair<TKey, TValue>[] _items;
+        private int _count;
+
+        public PairCollection()
+        {
+            _items = new Pair<TKey, TValue>[4];
+            _count = 0;
+        }
+
+        public int Count => _count;
+
+        public void Add(TKey key, TValue value)
+        {
+            if (_count == _items.Length)
+            {
+                var bigger = new Pair<TKey, TValue>[_items.Length * 2];
+                for (int i = 0; i < _count; i++) bigger[i] = _items[i];
+                _items = bigger;
+            }
+
+            _items[_count++] = new Pair<TKey, TValue>(key, value);
+        }
+
+        public Pair<TKey, TValue> GetAt(int index) => _items[index];
+
+        public IEnumerator GetEnumerator() => _items.GetEnumerator();
+    }
+
+    public class GenericInterfaceTypeSpecTests
+    {
+        public GenericInterfaceTypeSpecTests()
+        {
+            Console.WriteLine("++++++++++++++++++++++++++++++++++++++++");
+            Console.WriteLine("++ GenericInterfaceTypeSpec Tests      ++");
+            Console.WriteLine("++++++++++++++++++++++++++++++++++++++++");
+
+            var pairs = new PairCollection<int, string>();
+            pairs.Add(1, "one");
+            pairs.Add(2, "two");
+            pairs.Add(3, "three");
+            pairs.Add(4, "four");
+            pairs.Add(5, "five"); // forces _items growth: exercises new Pair<TKey,TValue>[] allocation
+
+            // Validate resize occurred: _count must be 5 and all previous elements preserved
+            if (pairs.Count != 5) throw new Exception($"Expected Count 5 but got {pairs.Count}");
+
+            string[] expected = { "one", "two", "three", "four", "five" };
+            for (int i = 0; i < pairs.Count; i++)
+            {
+                Pair<int, string> p = pairs.GetAt(i);
+                if (p.Key != i + 1 || p.Value != expected[i])
+                    throw new Exception($"Element at {i} mismatch: [{p.Key}]={p.Value}");
+                Console.WriteLine($"  [{p.Key}] = {p.Value}");
+            }
+        }
+    }
+}

--- a/MetadataProcessor.Tests/TestNFApp/Program.cs
+++ b/MetadataProcessor.Tests/TestNFApp/Program.cs
@@ -96,6 +96,10 @@ namespace TestNFApp
             Console.WriteLine("ReadOnlySpan<> tests");
             _ = new TestingReadOnlySpan();
 
+            // generic interface TypeSpec regression test
+            Console.WriteLine("GenericInterfaceTypeSpec tests");
+            _ = new GenericInterfaceTypeSpecTests();
+
             // 
             Console.WriteLine("Exiting TestNFApp");
         }

--- a/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
+++ b/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
@@ -40,6 +40,7 @@
     <Compile Include="TestingReadOnlySpan.cs" />
     <Compile Include="TestingSpan.cs" />
     <Compile Include="TestingDestructors.cs" />
+    <Compile Include="GenericInterfaceTypeSpecTests.cs" />
     <Compile Include="TestingDelegates.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
- Fix FillTypeSpecsFromTypes() for not scanning interface implementations.
- RemoveEmptyItems() was removing TypeSpecs with no member refs without checking whether the TypeSpec is used as an interface type.
- Dumper generator now properly deals with typespecs without member references.
- Add code to test app to cover these situations.

## Motivation and Context
- Edge case surface when working on adding `Dictionary<T,V>` to System.Collections.
- Related with nanoframework/Home#782.
- [tested against nanoclr buildId 61101].

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Added new code to test this in TestNFApp project.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
