### PR TITLE
Fix asserts for TypeSpecs not in lookup table

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTypeSpecificationsTable.cs
@@ -252,11 +252,11 @@ namespace nanoFramework.Tools.MetadataProcessor
                         // get index of signature for the TypeSpecification 
                         ushort signatureId = _context.SignaturesTable.GetOrCreateSignatureId(m.DeclaringType);
 
-                        if (!_idByTypeSpecifications.TryGetValue(m.DeclaringType, out ushort referenceId))
-                        {
-                            // is not on the list yet, add it
-                            _idByTypeSpecifications.Add(m.DeclaringType, signatureId);
-                        }
+                        // Use AddIfNew so the entry lands in both _idByTypeSpecifications and
+                        // _indexByTypeReference, making it reachable by TryGetTypeReferenceId.
+                        // RID==0 entries (open generics synthesised by Mono.Cecil for method bodies)
+                        // are intentionally skipped by AddIfNew.
+                        AddIfNew(m.DeclaringType, signatureId);
                     }
                 }
             }
@@ -269,7 +269,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                 {
                     // create or get the signature ID for this instanced type
                     ushort sigId = _context.SignaturesTable.GetOrCreateSignatureId(genericInstanceType);
-                    _idByTypeSpecifications.Add(genericInstanceType, sigId);
+                    AddIfNew(genericInstanceType, sigId);
 
                     // (and don’t forget to pull in any nested generic-parameter args)
                     foreach (GenericParameter arg in genericInstanceType.GenericArguments.OfType<GenericParameter>())
@@ -277,7 +277,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                         if (!_idByTypeSpecifications.ContainsKey(arg) && !arg.IsToExclude())
                         {
                             ushort argSig = _context.SignaturesTable.GetOrCreateSignatureId(arg);
-                            _idByTypeSpecifications.Add(arg, argSig);
+                            AddIfNew(arg, argSig);
                         }
                     }
                 }
@@ -298,7 +298,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                 if (!_idByTypeSpecifications.ContainsKey(typeRefItem) && !typeRefItem.IsToExclude())
                 {
                     ushort sigId = _context.SignaturesTable.GetOrCreateSignatureId(typeRefItem);
-                    _idByTypeSpecifications.Add(typeRefItem, sigId);
+                    AddIfNew(typeRefItem, sigId);
                     ExpandNestedTypeSpecs(typeRefItem);
                 }
             }
@@ -334,7 +334,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                                 && !genericInstanceType.IsToExclude())
                             {
                                 ushort sigId = _context.SignaturesTable.GetOrCreateSignatureId(genericInstanceType);
-                                _idByTypeSpecifications.Add(genericInstanceType, sigId);
+                                AddIfNew(genericInstanceType, sigId);
 
                                 // also pull in its element‐type and args
                                 ExpandNestedTypeSpecs(genericInstanceType);

--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -369,7 +369,13 @@ namespace nanoFramework.Tools.MetadataProcessor
                                 }
                                 else
                                 {
-                                    Debug.Fail($"Couldn't find a TypeSpec entry for {mr.DeclaringType}");
+                                    // TypeSpec not in the table - two benign scenarios:
+                                    // 1. RID == 0: open generic synthesised by Mono.Cecil inside a generic method body
+                                    //    (e.g. Pair<!0,!1> inside PairCollection<TKey,TValue>); encoded inline, never a table row.
+                                    // 2. Added only to _idByTypeSpecifications (not _indexByTypeReference) by
+                                    //    FillTypeSpecsFromMemberReferences - TryGetTypeReferenceId cannot find it.
+                                    // In both cases the element-type token below is sufficient; the TypeSpec
+                                    // table is rebuilt fresh by ResetTypeSpecificationsTable().
                                 }
 
                                 // add the metadata token for the element type
@@ -514,7 +520,11 @@ namespace nanoFramework.Tools.MetadataProcessor
                                     }
                                     else
                                     {
-                                        Debug.Fail($"Couldn't find a TypeSpec entry for {fr.DeclaringType}");
+                                        // TypeSpec not in the table - two benign scenarios:
+                                        // 1. RID == 0: open generic synthesised by Mono.Cecil inside a generic method body.
+                                        // 2. Added only to _idByTypeSpecifications (not _indexByTypeReference) by
+                                        //    FillTypeSpecsFromMemberReferences - TryGetTypeReferenceId cannot find it.
+                                        // The element-type token below is sufficient; TypeSpec table is rebuilt fresh.
                                     }
 
                                     // add the metadata token for the element type


### PR DESCRIPTION
## Description
- Fix FillTypeSpecsFromMemberReferences to use AddIfNew instead of adding directly to _idByTypeSpecifications, so RID!=0 TypeSpecs from member references are now reachable via TryGetTypeReferenceId.
- Remove asserts in Minimize() and replace with explanatory comment in case someone debugging this code hits the else.

## Motivation and Context
- Related with nanoframework/Home#782.
- [tested against nanoclr buildId 61058].

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
