### PR TITLE
Fixes in stubs generator

### DIFF
--- a/MetadataProcessor.Shared/Extensions/TypeDefinitionExtensions.cs
+++ b/MetadataProcessor.Shared/Extensions/TypeDefinitionExtensions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Mono.Cecil;
+using nanoFramework.Tools.MetadataProcessor;
 
 namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
 {
@@ -109,6 +110,11 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
                 }
             }
 
+            // Sanitize the enum name so that generic-type notation (backtick, angle brackets)
+            // does not produce invalid C++ identifiers (e.g. Dictionary`2_InsertionBehavior →
+            // Dictionary_2_InsertionBehavior).
+            enumName = NativeMethodsCrc.CleanupGenericName(enumName);
+
             EnumDeclaration myEnum = new EnumDeclaration()
             {
                 EnumName = enumName,
@@ -129,7 +135,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Core.Extensions
                     // pattern: nnnn_yyyyy
                     var emunItem = new EnumItem()
                     {
-                        Name = $"{enumName}_{f.Name}",
+                        Name = NativeMethodsCrc.CleanupGenericName($"{enumName}_{f.Name}"),
                     };
 
                     emunItem.Value = f.Constant.ToString();

--- a/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
+++ b/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
@@ -228,7 +228,11 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         internal static string CleanupGenericName(string name)
         {
-            // Remove generic type notation: anything like <T>, <T1,T2>, `, etc.
+            // Replace the CLR backtick-N generic arity notation with an underscore
+            // (e.g. Dictionary`2 → Dictionary_2). The trailing _N is the arity of the
+            // generic type and is the correct disambiguation token — it is unique per
+            // type definition and matches what the rest of the toolchain (CRC, method
+            // lookup) emits.
             string fixedName = name
                     .Replace('`', '_');
 

--- a/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
+++ b/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
@@ -459,12 +459,20 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
                         Name = NativeMethodsCrc.GetSafeClassName(c)
                     };
 
-                    // If class name starts from <PrivateImplementationDetails>,
-                    // then we need to exclude this class as actually this is static data object 
-                    // described in metadata.
-                    if (classData.Name.StartsWith("<PrivateImplementationDetails>"))
+                    // Exclude Roslyn-generated compiler helper type <PrivateImplementationDetails>
+                    // which holds embedded static data (hash-named fields) and has no nanoFramework relevance.
+                    // Check the original type name (c.Name) because the sanitized classData.Name has
+                    // angle-bracket content stripped, leaving an empty string that never matches.
+                    if (c.Name.StartsWith("<PrivateImplementationDetails>"))
                     {
                         // Go to the next class. This metadata describes global variable, not a type
+                        continue;
+                    }
+
+                    // Guard against any other compiler-generated type whose sanitized name is empty,
+                    // which would produce a broken struct name (e.g. Library_nf_system_collections_).
+                    if (string.IsNullOrWhiteSpace(classData.Name))
+                    {
                         continue;
                     }
 


### PR DESCRIPTION
## Description
- Fix invalid enum name generation from generic class.
- Improve clarification comment on how name clean up work for generic arity notation.
- Fix condition of excluding PrivateImplementationDetails classes.

## Motivation and Context
- Issues found when working in Dictionary implementation.
- Related with nanoframework/Home#782.
- [tested against nanoclr buildId 61142].


## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Now building successfully the stubs for that assembly.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
