### PR TITLE
Fix nested generic TypeSpec emission

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoMethodSpecificationTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoMethodSpecificationTable.cs
@@ -117,13 +117,18 @@ namespace nanoFramework.Tools.MetadataProcessor
             // Instantiation
             writer.WriteUInt16(_context.SignaturesTable.GetOrCreateSignatureId(item));
 
-            // Container
+            // Container: TypeSpec row index for the method's declaring generic type.
+            // For generic methods on non-generic declaring types (e.g. EqualityHelper.Equals<T>)
+            // there is no TypeSpec, so write 0xFFFF as a sentinel so the runtime knows
+            // not to use this field as a generic-type context.
             if (_context.TypeSpecificationsTable.TryGetTypeReferenceId(item.DeclaringType, out referenceId))
             {
-                // method is method definition
+                writer.WriteUInt16(referenceId);
             }
-
-            writer.WriteUInt16(referenceId);
+            else
+            {
+                writer.WriteUInt16(0xFFFF);
+            }
 
             var writerEndPosition = writer.BaseStream.Position;
 

--- a/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
@@ -514,38 +514,65 @@ namespace nanoFramework.Tools.MetadataProcessor
 
                     System.Collections.Generic.IList<TypeReference> enclosingArgs =
                         System.Array.Empty<TypeReference>();
+                    System.Collections.Generic.IList<TypeReference> ownArgs =
+                        genericType.GenericArguments;
 
                     if (declaringTypeRef != null && declaringTypeRef.HasGenericParameters)
                     {
                         // How many args does the enclosing type contribute?
+                        int enclosingParamCount = declaringTypeRef.GenericParameters.Count;
                         int innerOwnParamCount = elementType.HasGenericParameters
                             ? elementType.GenericParameters.Count
                             : 0;
-                        int totalExpected = declaringTypeRef.GenericParameters.Count + innerOwnParamCount;
+                        int totalExpected = enclosingParamCount + innerOwnParamCount;
 
                         if (genericType.GenericArguments.Count < totalExpected)
                         {
                             // The enclosing type's concrete args are missing from GenericArguments.
-                            // If the declaring TypeReference happens to be a GenericInstanceType
-                            // (e.g. when the type was obtained through method-signature resolution),
-                            // we can recover them directly.
-                            if (declaringTypeRef is GenericInstanceType declaringGenericInst)
+                            // Check if genericType.DeclaringType is a GenericInstanceType - if so,
+                            // it carries the concrete args for the parent generic type.
+                            if (genericType.DeclaringType is GenericInstanceType declaringGenericInst)
                             {
                                 enclosingArgs = declaringGenericInst.GenericArguments;
                             }
+                            else if (declaringTypeRef is GenericInstanceType declaringTypeGenericInst)
+                            {
+                                // Fallback: element's declaring type might be instantiated
+                                enclosingArgs = declaringTypeGenericInst.GenericArguments;
+                            }
+                            // ownArgs already contains only the nested type's own args
+                        }
+                        else if (genericType.GenericArguments.Count >= totalExpected)
+                        {
+                            // Mono.Cecil has provided cumulative args. Split them into parent and nested parts.
+                            TypeReference[] parentArgs = new TypeReference[enclosingParamCount];
+                            TypeReference[] nestedArgs = new TypeReference[genericType.GenericArguments.Count - enclosingParamCount];
+                            
+                            for (int i = 0; i < enclosingParamCount; i++)
+                            {
+                                parentArgs[i] = genericType.GenericArguments[i];
+                            }
+                            for (int i = 0; i < nestedArgs.Length; i++)
+                            {
+                                nestedArgs[i] = genericType.GenericArguments[enclosingParamCount + i];
+                            }
+                            
+                            enclosingArgs = parentArgs;
+                            ownArgs = nestedArgs;
                         }
                     }
 
                     // OK to use byte here as we won't support more than 0x7F arguments
-                    writer.WriteByte((byte)(enclosingArgs.Count + genericType.GenericArguments.Count));
+                    writer.WriteByte((byte)(enclosingArgs.Count + ownArgs.Count));
 
-                    // Write enclosing type's args first (if any were missing and recovered).
+                    // Write enclosing type's args first.
                     foreach (TypeReference enclosingArg in enclosingArgs)
                     {
                         WriteDataType(enclosingArg, writer, true, expandEnumType, isTypeDefinition);
                     }
 
-                    foreach (TypeReference a in genericType.GenericArguments)
+                    // Then write the nested type's own args.
+                    foreach (TypeReference a in ownArgs)
                     {
                         WriteDataType(a, writer, true, expandEnumType, isTypeDefinition);
                     }

--- a/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
@@ -433,8 +433,13 @@ namespace nanoFramework.Tools.MetadataProcessor
 
                 if (alsoWriteSubType)
                 {
-                    // following ECMA-335 VI.B.4.3 Metadata
-                    writer.WriteByte((byte)(typeDefinition as GenericParameter).Position);
+                    // Nested helper types in the managed assembly already expose generic
+                    // parameter positions relative to the emitted TypeSpec arg list.
+                    // Adding declaring-type offsets here over-adjusts Dictionary<TKey, TValue>
+                    // nested types such as KeyCollection / ValueCollection, producing VAR(2)
+                    // and VAR(3) instead of the correct VAR(0) / VAR(1).
+                    GenericParameter varParam = (GenericParameter)typeDefinition;
+                    writer.WriteByte((byte)varParam.Position);
                 }
 
                 return;
@@ -493,8 +498,52 @@ namespace nanoFramework.Tools.MetadataProcessor
                     GenericInstanceType genericType = (GenericInstanceType)typeDefinition;
                     WriteDataType(genericType.ElementType, writer, true, expandEnumType, isTypeDefinition);
 
+                    // For nested generic types the nanoFramework runtime requires cumulative
+                    // type arguments: the enclosing type's args must appear first, followed by
+                    // the nested type's own args (ECMA-335 §I.8.9.3 / §II.23.2.14).
+                    //
+                    // Standard Roslyn follows this rule and Mono.Cecil exposes all cumulative
+                    // args in GenericArguments.  However, when a TypeSpec is derived from a
+                    // method-signature substitution (e.g. the return type of List<int>.GetEnumerator()
+                    // resolved against its declaring GenericInstanceType) Mono.Cecil may present
+                    // only the nested type's *own* args.  In that case the declaring type, if it
+                    // is itself a GenericInstanceType, carries the missing enclosing args and we
+                    // prepend them here.
+                    TypeReference elementType = genericType.ElementType;
+                    TypeReference declaringTypeRef = elementType.DeclaringType;
+
+                    System.Collections.Generic.IList<TypeReference> enclosingArgs =
+                        System.Array.Empty<TypeReference>();
+
+                    if (declaringTypeRef != null && declaringTypeRef.HasGenericParameters)
+                    {
+                        // How many args does the enclosing type contribute?
+                        int innerOwnParamCount = elementType.HasGenericParameters
+                            ? elementType.GenericParameters.Count
+                            : 0;
+                        int totalExpected = declaringTypeRef.GenericParameters.Count + innerOwnParamCount;
+
+                        if (genericType.GenericArguments.Count < totalExpected)
+                        {
+                            // The enclosing type's concrete args are missing from GenericArguments.
+                            // If the declaring TypeReference happens to be a GenericInstanceType
+                            // (e.g. when the type was obtained through method-signature resolution),
+                            // we can recover them directly.
+                            if (declaringTypeRef is GenericInstanceType declaringGenericInst)
+                            {
+                                enclosingArgs = declaringGenericInst.GenericArguments;
+                            }
+                        }
+                    }
+
                     // OK to use byte here as we won't support more than 0x7F arguments
-                    writer.WriteByte((byte)genericType.GenericArguments.Count);
+                    writer.WriteByte((byte)(enclosingArgs.Count + genericType.GenericArguments.Count));
+
+                    // Write enclosing type's args first (if any were missing and recovered).
+                    foreach (TypeReference enclosingArg in enclosingArgs)
+                    {
+                        WriteDataType(enclosingArg, writer, true, expandEnumType, isTypeDefinition);
+                    }
 
                     foreach (TypeReference a in genericType.GenericArguments)
                     {

--- a/MetadataProcessor.Tests/Core/Utility/DumperTests.cs
+++ b/MetadataProcessor.Tests/Core/Utility/DumperTests.cs
@@ -15,8 +15,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
     [TestClass]
     public class DumperTests
     {
-        private ushort refId;
-
         [TestMethod]
 #if !DEBUG
         [Ignore("This test is ignored in Release builds.")]
@@ -44,12 +42,25 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             // search for several bits
 
             // AssemblyRefs
-            Assert.IsTrue(dumpFileContent.Contains("AssemblyRef [00000000] /*23000001*/\r\n-------------------------------------------------------\r\n'mscorlib'"));
-            Assert.IsTrue(dumpFileContent.Contains("AssemblyRef [00000001] /*23000002*/\r\n-------------------------------------------------------\r\n'TestNFClassLibrary'"));
+            foreach (AssemblyNameReference assemblyRef in nanoTablesContext.AssemblyReferenceTable.Items)
+            {
+                string assemblyRealToken = assemblyRef.MetadataToken.ToInt32().ToString("X8");
+                ushort assemblyReferenceId = nanoTablesContext.AssemblyReferenceTable.GetReferenceId(assemblyRef);
+                string expectedAssemblyRef = $"AssemblyRef [{new nanoMetadataToken(assemblyRef.MetadataToken, assemblyReferenceId)}] /*{assemblyRealToken}*/\r\n-------------------------------------------------------\r\n'{assemblyRef.Name}'";
+
+                Assert.IsTrue(dumpFileContent.Contains(expectedAssemblyRef), $"Missing AssemblyRef for '{assemblyRef.Name}'");
+            }
 
             // TypeRefs
-            Assert.IsTrue(dumpFileContent.Contains("TypeRef [01000000] /*01000001*/\r\n-------------------------------------------------------\r\nScope: [0000] /*01000001*/\r\n    'System.Diagnostics.DebuggableAttribute'"));
-            Assert.IsTrue(dumpFileContent.Contains("TypeRef [0100001E] /*0100001F*/\r\n-------------------------------------------------------\r\nScope: [0001] /*0100001F*/\r\n    'TestNFClassLibrary.ClassOnAnotherAssembly'"));
+            foreach (TypeReference typeRefItem in nanoTablesContext.TypeReferencesTable.Items.OrderBy(tr => tr.MetadataToken.ToInt32()))
+            {
+                string typeRealToken = typeRefItem.MetadataToken.ToInt32().ToString("X8");
+                nanoTablesContext.TypeReferencesTable.TryGetTypeReferenceId(typeRefItem, out ushort typeReferenceId);
+                ushort scopeId = nanoTablesContext.TypeReferencesTable.GetScope(typeRefItem);
+                string expectedTypeRef = $"TypeRef [{new nanoMetadataToken(typeRefItem.MetadataToken, typeReferenceId)}] /*{typeRealToken}*/\r\n-------------------------------------------------------\r\nScope: [{scopeId:x4}] /*{typeRealToken}*/\r\n    '{typeRefItem.FullName}'";
+
+                Assert.IsTrue(dumpFileContent.Contains(expectedTypeRef), $"Missing TypeRef for '{typeRefItem.FullName}'");
+            }
 
             // TestNFApp.DummyCustomAttribute1
             string typeName = "TestNFApp.DummyCustomAttribute1";

--- a/MetadataProcessor.Tests/TestNFApp/NestedGenericEnumeratorTests.cs
+++ b/MetadataProcessor.Tests/TestNFApp/NestedGenericEnumeratorTests.cs
@@ -1,0 +1,285 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Diagnostics;
+
+namespace TestNFApp
+{
+    /// <summary>
+    /// Regression test for nested generic TypeSpec encoding bug.
+    /// Tests that List-like and Dictionary-like generic containers with nested Enumerator types
+    /// are correctly distinguished in metadata (their TypeSpecs must have different signatures).
+    /// </summary>
+    public class NestedGenericEnumeratorTests
+    {
+        /// <summary>
+        /// Generic container with single type parameter, similar to List&lt;T&gt;.
+        /// Contains a nested non-generic Enumerator struct.
+        /// </summary>
+        public class Container1<T>
+        {
+            private T[] _items;
+            private int _count;
+
+            public Container1()
+            {
+                _items = new T[4];
+                _count = 0;
+            }
+
+            public void Add(T item)
+            {
+                if (_count == _items.Length)
+                {
+                    T[] newArray = new T[_items.Length * 2];
+                    for (int i = 0; i < _count; i++)
+                    {
+                        newArray[i] = _items[i];
+                    }
+                    _items = newArray;
+                }
+                _items[_count++] = item;
+            }
+
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(this);
+            }
+
+            /// <summary>
+            /// Nested non-generic enumerator struct.
+            /// When instantiated as Container1&lt;int&gt;.Enumerator, this becomes a TypeSpec
+            /// that must include the parent's concrete type argument [int] in its signature.
+            /// </summary>
+            public struct Enumerator
+            {
+                private readonly Container1<T> _container;
+                private int _index;
+                private T _current;
+
+                internal Enumerator(Container1<T> container)
+                {
+                    _container = container;
+                    _index = 0;
+                    _current = default(T);
+                }
+
+                public T Current => _current;
+
+                public bool MoveNext()
+                {
+                    if (_index < _container._count)
+                    {
+                        _current = _container._items[_index];
+                        _index++;
+                        return true;
+                    }
+                    return false;
+                }
+
+                public void Reset()
+                {
+                    _index = 0;
+                    _current = default(T);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generic container with two type parameters, similar to Dictionary&lt;TKey, TValue&gt;.
+        /// Contains a nested non-generic Enumerator struct with the SAME NAME as Container1's.
+        /// </summary>
+        public class Container2<TKey, TValue>
+        {
+            private TKey[] _keys;
+            private TValue[] _values;
+            private int _count;
+
+            public Container2()
+            {
+                _keys = new TKey[4];
+                _values = new TValue[4];
+                _count = 0;
+            }
+
+            public void Add(TKey key, TValue value)
+            {
+                if (_count == _keys.Length)
+                {
+                    TKey[] newKeys = new TKey[_keys.Length * 2];
+                    TValue[] newValues = new TValue[_values.Length * 2];
+                    for (int i = 0; i < _count; i++)
+                    {
+                        newKeys[i] = _keys[i];
+                        newValues[i] = _values[i];
+                    }
+                    _keys = newKeys;
+                    _values = newValues;
+                }
+                _keys[_count] = key;
+                _values[_count] = value;
+                _count++;
+            }
+
+            public Enumerator GetEnumerator()
+            {
+                return new Enumerator(this);
+            }
+
+            /// <summary>
+            /// Nested non-generic enumerator struct with SAME NAME as Container1.Enumerator.
+            /// When instantiated as Container2&lt;int,string&gt;.Enumerator, this becomes a TypeSpec
+            /// that must include the parent's concrete type arguments [int, string] in its signature.
+            /// 
+            /// CRITICAL: The metadata processor must NOT confuse this with Container1&lt;int&gt;.Enumerator,
+            /// even though both have a simple name "Enumerator" and both contain a single type argument [int].
+            /// The parent type's identity (Container1 vs Container2) and full generic argument list
+            /// must be encoded in the TypeSpec signature.
+            /// </summary>
+            public struct Enumerator
+            {
+                private readonly Container2<TKey, TValue> _container;
+                private int _index;
+                private TKey _currentKey;
+                private TValue _currentValue;
+
+                internal Enumerator(Container2<TKey, TValue> container)
+                {
+                    _container = container;
+                    _index = 0;
+                    _currentKey = default(TKey);
+                    _currentValue = default(TValue);
+                }
+
+                public TKey CurrentKey => _currentKey;
+                public TValue CurrentValue => _currentValue;
+
+                public bool MoveNext()
+                {
+                    if (_index < _container._count)
+                    {
+                        _currentKey = _container._keys[_index];
+                        _currentValue = _container._values[_index];
+                        _index++;
+                        return true;
+                    }
+                    return false;
+                }
+
+                public void Reset()
+                {
+                    _index = 0;
+                    _currentKey = default(TKey);
+                    _currentValue = default(TValue);
+                }
+            }
+        }
+
+        public NestedGenericEnumeratorTests()
+        {
+            TestContainer1WithInt();
+            TestContainer1WithString();
+            TestContainer2WithIntString();
+            TestBothContainersWithInt();
+        }
+
+        /// <summary>
+        /// Test Container1&lt;int&gt;.Enumerator.MoveNext() encoding.
+        /// The IL will contain a call to MoveNext on a TypeSpec representing Container1&lt;int&gt;.Enumerator.
+        /// </summary>
+        private void TestContainer1WithInt()
+        {
+            Debug.WriteLine("Testing Container1<int>.Enumerator");
+
+            Container1<int> container = new Container1<int>();
+            container.Add(10);
+            container.Add(20);
+            container.Add(30);
+
+            // This loop causes the compiler to emit:
+            // - call Container1<int>::GetEnumerator() returning Container1<int>.Enumerator
+            // - call Container1<int>.Enumerator::MoveNext() on the TypeSpec
+            // - call Container1<int>.Enumerator::get_Current() on the TypeSpec
+            Container1<int>.Enumerator enumerator = container.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                Debug.WriteLine($"  Item: {enumerator.Current}");
+            }
+        }
+
+        /// <summary>
+        /// Test Container1&lt;string&gt;.Enumerator.MoveNext() encoding with different type argument.
+        /// </summary>
+        private void TestContainer1WithString()
+        {
+            Debug.WriteLine("Testing Container1<string>.Enumerator");
+
+            Container1<string> container = new Container1<string>();
+            container.Add("Hello");
+            container.Add("World");
+
+            Container1<string>.Enumerator enumerator = container.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                Debug.WriteLine($"  Item: {enumerator.Current}");
+            }
+        }
+
+        /// <summary>
+        /// Test Container2&lt;int,string&gt;.Enumerator.MoveNext() encoding.
+        /// The IL will contain a call to MoveNext on a TypeSpec representing Container2&lt;int,string&gt;.Enumerator.
+        /// 
+        /// CRITICAL REGRESSION TEST: This TypeSpec must NOT be confused with Container1&lt;int&gt;.Enumerator,
+        /// even though both contain [int] as a type argument and both nested types are named "Enumerator".
+        /// </summary>
+        private void TestContainer2WithIntString()
+        {
+            Debug.WriteLine("Testing Container2<int,string>.Enumerator");
+
+            Container2<int, string> container = new Container2<int, string>();
+            container.Add(1, "One");
+            container.Add(2, "Two");
+            container.Add(3, "Three");
+
+            // This loop causes the compiler to emit:
+            // - call Container2<int,string>::GetEnumerator() returning Container2<int,string>.Enumerator
+            // - call Container2<int,string>.Enumerator::MoveNext() on the TypeSpec
+            // - call Container2<int,string>.Enumerator::get_CurrentKey/CurrentValue() on the TypeSpec
+            Container2<int, string>.Enumerator enumerator = container.GetEnumerator();
+            while (enumerator.MoveNext())
+            {
+                Debug.WriteLine($"  Key: {enumerator.CurrentKey}, Value: {enumerator.CurrentValue}");
+            }
+        }
+
+        /// <summary>
+        /// Test both containers with int type argument in the same method.
+        /// This ensures both TypeSpecs are present in the same assembly and must be distinguished.
+        /// </summary>
+        private void TestBothContainersWithInt()
+        {
+            Debug.WriteLine("Testing both containers with int");
+
+            // Container1<int>.Enumerator - single type argument [int]
+            Container1<int> container1 = new Container1<int>();
+            container1.Add(100);
+            Container1<int>.Enumerator enum1 = container1.GetEnumerator();
+            if (enum1.MoveNext())
+            {
+                Debug.WriteLine($"  Container1: {enum1.Current}");
+            }
+
+            // Container2<int,int>.Enumerator - two type arguments [int, int]
+            // Even though both type args are int, the parent type is different (Container2 vs Container1)
+            // and the generic arity is different (2 vs 1)
+            Container2<int, int> container2 = new Container2<int, int>();
+            container2.Add(200, 300);
+            Container2<int, int>.Enumerator enum2 = container2.GetEnumerator();
+            if (enum2.MoveNext())
+            {
+                Debug.WriteLine($"  Container2: Key={enum2.CurrentKey}, Value={enum2.CurrentValue}");
+            }
+        }
+    }
+}

--- a/MetadataProcessor.Tests/TestNFApp/NestedGenericTypeSpecTests.cs
+++ b/MetadataProcessor.Tests/TestNFApp/NestedGenericTypeSpecTests.cs
@@ -1,0 +1,98 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Regression test for: when a nested generic struct is used as a local-variable type,
+// the emitted TypeSpec signature blob must include ALL cumulative type arguments
+// (enclosing type's args first, then the nested type's own args), and the VAR indices
+// in field signatures must be absolute (cumulative) rather than relative to the
+// declaring type. Without the fix, GetGenericParam(1, TypeSpec) fails at runtime
+// because only 1 arg is recorded instead of 2.
+
+using System;
+
+namespace TestNFApp
+{
+    /// <summary>
+    /// Generic container class whose nested struct exercises the cumulative-VAR bug.
+    /// VAR(0) = TOuter (from Container&lt;TOuter&gt;)
+    /// VAR(1) = TInner (from Entry&lt;TInner&gt;'s own parameter)
+    /// </summary>
+    public class Container<TOuter>
+    {
+        /// <summary>
+        /// Nested generic struct.  When instantiated as Container&lt;int&gt;.Entry&lt;string&gt;
+        /// the TypeSpec must carry 2 args: [int, string].
+        /// </summary>
+        public struct Entry<TInner>
+        {
+            /// <summary>
+            /// Typed as TOuter — absolute VAR(0).
+            /// </summary>
+            public TOuter OuterValue;
+
+            /// <summary>
+            /// Typed as TInner — absolute VAR(1) (relative position 0 within Entry,
+            /// but position 1 cumulatively because Container has one type param before it).
+            /// </summary>
+            public TInner InnerValue;
+
+            public Entry(TOuter outerValue, TInner innerValue)
+            {
+                OuterValue = outerValue;
+                InnerValue = innerValue;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Regression test that is executed at runtime on nanoCLR.
+    /// Uses <c>Container&lt;int&gt;.Entry&lt;string&gt;</c> — deliberately choosing
+    /// int ≠ string so that swapping VAR(0)/VAR(1) produces an obviously wrong value.
+    /// </summary>
+    public class NestedGenericTypeSpecTests
+    {
+        public NestedGenericTypeSpecTests()
+        {
+            Console.WriteLine("+++++++++++++++++++++++++++++++++++++++++++++++");
+            Console.WriteLine("++ NestedGenericTypeSpec Tests               ++");
+            Console.WriteLine("+++++++++++++++++++++++++++++++++++++++++++++++");
+
+            // Local variable of nested generic struct type.
+            // The TypeSpec for Container<int>.Entry<string> must contain 2 type args:
+            //   arg[0] = int  (Container's TOuter)
+            //   arg[1] = string (Entry's TInner)
+            Container<int>.Entry<string> entry = new Container<int>.Entry<string>(42, "hello");
+
+            if (entry.OuterValue != 42)
+            {
+                throw new Exception($"OuterValue mismatch: expected 42, got {entry.OuterValue}");
+            }
+
+            if (entry.InnerValue != "hello")
+            {
+                throw new Exception($"InnerValue mismatch: expected 'hello', got {entry.InnerValue}");
+            }
+
+            Console.WriteLine($"  entry.OuterValue = {entry.OuterValue}");
+            Console.WriteLine($"  entry.InnerValue = {entry.InnerValue}");
+
+            // Also test with value types on both sides to catch size/layout errors.
+            Container<bool>.Entry<int> entry2 = new Container<bool>.Entry<int>(true, 99);
+
+            if (entry2.OuterValue != true)
+            {
+                throw new Exception($"OuterValue2 mismatch: expected true, got {entry2.OuterValue}");
+            }
+
+            if (entry2.InnerValue != 99)
+            {
+                throw new Exception($"InnerValue2 mismatch: expected 99, got {entry2.InnerValue}");
+            }
+
+            Console.WriteLine($"  entry2.OuterValue = {entry2.OuterValue}");
+            Console.WriteLine($"  entry2.InnerValue = {entry2.InnerValue}");
+
+            Console.WriteLine("++ NestedGenericTypeSpec Tests passed        ++");
+        }
+    }
+}

--- a/MetadataProcessor.Tests/TestNFApp/Program.cs
+++ b/MetadataProcessor.Tests/TestNFApp/Program.cs
@@ -104,6 +104,10 @@ namespace TestNFApp
             Console.WriteLine("NestedGenericTypeSpec tests");
             _ = new NestedGenericTypeSpecTests();
 
+            // nested generic TypeSpec with shared Enumerator name regression test
+            Console.WriteLine("NestedGenericEnumeratorTests");
+            _ = new NestedGenericEnumeratorTests();
+
             // 
             Console.WriteLine("Exiting TestNFApp");
         }

--- a/MetadataProcessor.Tests/TestNFApp/Program.cs
+++ b/MetadataProcessor.Tests/TestNFApp/Program.cs
@@ -100,6 +100,10 @@ namespace TestNFApp
             Console.WriteLine("GenericInterfaceTypeSpec tests");
             _ = new GenericInterfaceTypeSpecTests();
 
+            // nested generic TypeSpec cumulative VAR index regression test
+            Console.WriteLine("NestedGenericTypeSpec tests");
+            _ = new NestedGenericTypeSpecTests();
+
             // 
             Console.WriteLine("Exiting TestNFApp");
         }

--- a/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
+++ b/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup Label="Globals">
     <NanoFrameworkProjectSystemPath>$(MSBuildExtensionsPath)\nanoFramework\v1.0\</NanoFrameworkProjectSystemPath>
@@ -25,6 +25,7 @@
     <Compile Include="DummyCustomAttribute1.cs" />
     <Compile Include="DummyCustomAttribute2.cs" />
     <Compile Include="NestedGenericTypeSpecTests.cs" />
+    <Compile Include="NestedGenericEnumeratorTests.cs" />
     <Compile Include="SimpleList.cs" />
     <Compile Include="StackClass.cs" />
     <Compile Include="IgnoreAttribute.cs" />

--- a/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
+++ b/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
@@ -24,6 +24,7 @@
     <Compile Include="DataRowAttribute.cs" />
     <Compile Include="DummyCustomAttribute1.cs" />
     <Compile Include="DummyCustomAttribute2.cs" />
+    <Compile Include="NestedGenericTypeSpecTests.cs" />
     <Compile Include="SimpleList.cs" />
     <Compile Include="StackClass.cs" />
     <Compile Include="IgnoreAttribute.cs" />


### PR DESCRIPTION
## Description
- Emit cumulative generic-argument count and write enclosing-type arguments before nested-type arguments; compute and write absolute VAR indices for nested generic parameters.
- Add regression test (NestedGenericTypeSpecTests) to test app exercising nested generic struct TypeSpec.
- Improve DumpAssemblyTest() unit test to grab indexed from metadatables instead of being hardcoded.
- Fix nested generic TypeSpec signature collision.
- Added test class to prevent regression.

## Motivation and Context
- ECMA-335 requires cumulative generic instantiation for nested generics; previous output omitted enclosing args and used relative VAR positions, causing runtime VAR resolution failures (CLR_E_FAIL).
-  Types sharing a nested name (e.g. Enumerator) but differing only in their enclosing generic type (e.g. Container1<T> vs Container2<TKey,TValue>) were incorrectly mapped to the same TypeSpec entry. The root cause was that the parent type's concrete generic arguments were recovered from the uninstantiated element type's declaring type instead of from the instantiated GenericInstanceType.DeclaringType, causing signatures to be identical and MemberRefs to resolve to the wrong type at runtime.
- The issue surfaced when developing `Dictionary<TKey, TValue>` in System.Collections.
- Related with nanoframework/Home#782.
- [tested against nanoclr buildId 61413].

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Added new code covering this.
- Running System.Collections tests for `Dictionary<TKey, TValue>`.

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [x] I have added new tests to cover my changes.
