### PR TITLE
Fix custom attribute encoding for array and char args

### DIFF
--- a/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
@@ -903,7 +903,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                         break;
                     case NanoCLRDataType.DATATYPE_CHAR:
                         writer.Write((byte)nanoSerializationType.ELEMENT_TYPE_CHAR);
-                        writer.Write((char)argument.Value);
+                        writer.Write((ushort)(char)argument.Value);
                         break;
                     case NanoCLRDataType.DATATYPE_STRING:
                         writer.Write((byte)nanoSerializationType.ELEMENT_TYPE_STRING);
@@ -936,11 +936,127 @@ namespace nanoFramework.Tools.MetadataProcessor
                     WriteAttributeArgumentValue(writer, (CustomAttributeArgument)attributeArgument.Value);
                 }
             }
+            else if (argument.Type.IsArray)
+            {
+                var elementType = argument.Type.GetElementType();
+
+                if (!s_primitiveTypes.TryGetValue(elementType.FullName, out dataType) ||
+                    dataType == NanoCLRDataType.DATATYPE_VOID ||
+                    dataType == NanoCLRDataType.DATATYPE_OBJECT)
+                {
+                    throw new ArgumentException($"Failed to generate signature for CustomAttribute. Unsupported array type: {argument.Type.FullName}.");
+                }
+
+                writer.Write((byte)nanoSerializationType.ELEMENT_TYPE_SZARRAY);
+                WriteAttributeArrayArgumentValue(writer, dataType, (CustomAttributeArgument[])argument.Value);
+            }
 
             if (argument.Type.FullName == "System.Type")
             {
                 writer.Write((byte)nanoSerializationType.ELEMENT_TYPE_STRING);
                 writer.Write(_context.StringTable.GetOrCreateStringId(((TypeReference)argument.Value).FullName));
+            }
+        }
+
+        private void WriteAttributeArrayArgumentValue(
+            BinaryWriter writer,
+            NanoCLRDataType dataType,
+            CustomAttributeArgument[] arguments)
+        {
+            writer.Write((byte)GetSerializationType(dataType));
+            writer.Write((byte)arguments.Length);
+
+            foreach (var item in arguments)
+            {
+                WriteAttributeArrayElementValue(writer, dataType, item.Value);
+            }
+        }
+
+        private void WriteAttributeArrayElementValue(
+            BinaryWriter writer,
+            NanoCLRDataType dataType,
+            object value)
+        {
+            switch (dataType)
+            {
+                case NanoCLRDataType.DATATYPE_BOOLEAN:
+                    writer.Write((byte)((bool)value ? 1 : 0));
+                    break;
+                case NanoCLRDataType.DATATYPE_I1:
+                    writer.Write((sbyte)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_U1:
+                    writer.Write((byte)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_I2:
+                    writer.Write((short)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_U2:
+                    writer.Write((ushort)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_I4:
+                    writer.Write((int)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_U4:
+                    writer.Write((uint)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_I8:
+                    writer.Write((long)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_U8:
+                    writer.Write((ulong)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_R4:
+                    writer.Write((float)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_R8:
+                    writer.Write((double)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_CHAR:
+                    writer.Write((ushort)(char)value);
+                    break;
+                case NanoCLRDataType.DATATYPE_STRING:
+                    writer.Write(value == null
+                        ? (ushort)0xFFFF
+                        : _context.StringTable.GetOrCreateStringId((string)value));
+                    break;
+                default:
+                    throw new ArgumentException($"Failed to generate signature for CustomAttribute. Unsupported array element type: {dataType}.");
+            }
+        }
+
+        private static nanoSerializationType GetSerializationType(NanoCLRDataType dataType)
+        {
+            switch (dataType)
+            {
+                case NanoCLRDataType.DATATYPE_BOOLEAN:
+                    return nanoSerializationType.ELEMENT_TYPE_BOOLEAN;
+                case NanoCLRDataType.DATATYPE_CHAR:
+                    return nanoSerializationType.ELEMENT_TYPE_CHAR;
+                case NanoCLRDataType.DATATYPE_I1:
+                    return nanoSerializationType.ELEMENT_TYPE_I1;
+                case NanoCLRDataType.DATATYPE_U1:
+                    return nanoSerializationType.ELEMENT_TYPE_U1;
+                case NanoCLRDataType.DATATYPE_I2:
+                    return nanoSerializationType.ELEMENT_TYPE_I2;
+                case NanoCLRDataType.DATATYPE_U2:
+                    return nanoSerializationType.ELEMENT_TYPE_U2;
+                case NanoCLRDataType.DATATYPE_I4:
+                    return nanoSerializationType.ELEMENT_TYPE_I4;
+                case NanoCLRDataType.DATATYPE_U4:
+                    return nanoSerializationType.ELEMENT_TYPE_U4;
+                case NanoCLRDataType.DATATYPE_I8:
+                    return nanoSerializationType.ELEMENT_TYPE_I8;
+                case NanoCLRDataType.DATATYPE_U8:
+                    return nanoSerializationType.ELEMENT_TYPE_U8;
+                case NanoCLRDataType.DATATYPE_R4:
+                    return nanoSerializationType.ELEMENT_TYPE_R4;
+                case NanoCLRDataType.DATATYPE_R8:
+                    return nanoSerializationType.ELEMENT_TYPE_R8;
+                case NanoCLRDataType.DATATYPE_STRING:
+                    return nanoSerializationType.ELEMENT_TYPE_STRING;
+                default:
+                    throw new ArgumentException($"Failed to generate signature for CustomAttribute. Unsupported type: {dataType}.");
             }
         }
 

--- a/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
+++ b/MetadataProcessor.Shared/Tables/nanoSignaturesTable.cs
@@ -927,6 +927,12 @@ namespace nanoFramework.Tools.MetadataProcessor
             {
                 var paramCollection = (CustomAttributeArgument[])argument.Value;
 
+                if (paramCollection == null)
+                {
+                    throw new ArgumentException(
+                        $"Failed to generate signature for CustomAttribute. Null arrays are not supported for {argument.Type.FullName}.");
+                }
+
                 // add count of array elements that will follow
                 writer.Write((byte)paramCollection.Length);
 
@@ -947,8 +953,16 @@ namespace nanoFramework.Tools.MetadataProcessor
                     throw new ArgumentException($"Failed to generate signature for CustomAttribute. Unsupported array type: {argument.Type.FullName}.");
                 }
 
+                var values = (CustomAttributeArgument[])argument.Value;
+
+                if (values == null)
+                {
+                    throw new ArgumentException(
+                        $"Failed to generate signature for CustomAttribute. Null arrays are not supported for {argument.Type.FullName}.");
+                }
+
                 writer.Write((byte)nanoSerializationType.ELEMENT_TYPE_SZARRAY);
-                WriteAttributeArrayArgumentValue(writer, dataType, (CustomAttributeArgument[])argument.Value);
+                WriteAttributeArrayArgumentValue(writer, dataType, values);
             }
 
             if (argument.Type.FullName == "System.Type")
@@ -963,6 +977,13 @@ namespace nanoFramework.Tools.MetadataProcessor
             NanoCLRDataType dataType,
             CustomAttributeArgument[] arguments)
         {
+            if (arguments.Length > byte.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(arguments),
+                    $"Custom attribute arrays longer than {byte.MaxValue} elements are not supported by the current encoding.");
+            }
+
             writer.Write((byte)GetSerializationType(dataType));
             writer.Write((byte)arguments.Length);
 


### PR DESCRIPTION
## Description
- Encode primitive/string arrays inside attribute arguments and write char values as fixed 16-bit values instead of UTF-8. This keeps MDP proprietary attribute blob format aligned with the CLR attribute parser, including DataRow cases with byte[] and Unicode char values.

## Motivation and Context
- Found out when analysing unit tests in mscorlib. Turns out that NFUnitTestBitConverter test were silently failing for quite sometime. Reason being the incorrect encoding and parsing of attributes.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- Compiling and successfully running NFUnitTestBitConverter tests.
- [tested against nanoclr buildId 61539].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
