### PR TITLE
More diagnostic output added

### DIFF
--- a/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
+++ b/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
@@ -349,12 +349,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                     IsCoreLibrary);
 
                 Log.LogMessage(MessageImportance.Low, "[MDP] Tables context built:");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Type definitions    : {_assemblyBuilder.TablesContext.TypeDefinitionTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Method definitions  : {_assemblyBuilder.TablesContext.MethodDefinitionTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Field definitions   : {_assemblyBuilder.TablesContext.FieldsTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Assembly references : {_assemblyBuilder.TablesContext.AssemblyReferenceTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Type references     : {_assemblyBuilder.TablesContext.TypeReferencesTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Member references   : {_assemblyBuilder.TablesContext.MemberReferencesTable.Items.Count()}");
+                LogTablesDetailed();
 
                 LogExcludedTypesDetailed();
                 LogNativeCrcDetailed();
@@ -416,12 +411,7 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                 }
 
                 Log.LogMessage(MessageImportance.Low, "[MDP] Post-minimize tables:");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Type definitions    : {_assemblyBuilder.TablesContext.TypeDefinitionTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Method definitions  : {_assemblyBuilder.TablesContext.MethodDefinitionTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Field definitions   : {_assemblyBuilder.TablesContext.FieldsTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Assembly references : {_assemblyBuilder.TablesContext.AssemblyReferenceTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Type references     : {_assemblyBuilder.TablesContext.TypeReferencesTable.Items.Count()}");
-                Log.LogMessage(MessageImportance.Low, $"[MDP]   Member references   : {_assemblyBuilder.TablesContext.MemberReferencesTable.Items.Count()}");
+                LogTablesDetailed();
 
                 // compile assembly (2nd pass after minimize)
                 if (Verbose)
@@ -448,6 +438,8 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
 
                     Log.LogMessage(MessageImportance.Low, $"[MDP] Final PE size: {stream.Length} bytes -> '{fileName}'");
                 }
+
+                LogAssemblyDefinitionCrcDetailed();
 
                 startTime = DateTime.Now;
 
@@ -527,6 +519,71 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                     }
                 }
             }
+        }
+
+        private void LogTablesDetailed()
+        {
+            nanoTablesContext ctx = _assemblyBuilder.TablesContext;
+
+            // Type definitions
+            List<TypeDefinition> typeDefs = ctx.TypeDefinitionTable.Items.ToList();
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Type definitions    : {typeDefs.Count}");
+            foreach (TypeDefinition t in typeDefs)
+            {
+                Log.LogMessage(MessageImportance.Low, $"[MDP]     {t.FullName}");
+            }
+
+            // Method definitions
+            List<MethodDefinition> methodDefs = ctx.MethodDefinitionTable.Items.ToList();
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Method definitions  : {methodDefs.Count}");
+            foreach (MethodDefinition m in methodDefs)
+            {
+                Log.LogMessage(MessageImportance.Low, $"[MDP]     {m.DeclaringType.FullName}::{m.Name}");
+            }
+
+            // Field definitions
+            List<FieldDefinition> fieldDefs = ctx.FieldsTable.Items.ToList();
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Field definitions   : {fieldDefs.Count}");
+            foreach (FieldDefinition f in fieldDefs)
+            {
+                Log.LogMessage(MessageImportance.Low, $"[MDP]     {f.DeclaringType.FullName}::{f.Name}");
+            }
+
+            // Assembly references
+            List<AssemblyNameReference> asmRefs = ctx.AssemblyReferenceTable.Items.ToList();
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Assembly references : {asmRefs.Count}");
+            foreach (AssemblyNameReference a in asmRefs)
+            {
+                Log.LogMessage(MessageImportance.Low, $"[MDP]     {a.FullName}");
+            }
+
+            // Type references
+            List<TypeReference> typeRefs = ctx.TypeReferencesTable.Items.ToList();
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Type references     : {typeRefs.Count}");
+            foreach (TypeReference t in typeRefs)
+            {
+                Log.LogMessage(MessageImportance.Low, $"[MDP]     {t.FullName}");
+            }
+
+            // Member references
+            List<MemberReference> memberRefs = ctx.MemberReferencesTable.Items.ToList();
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Member references   : {memberRefs.Count}");
+            foreach (MemberReference m in memberRefs)
+            {
+                Log.LogMessage(MessageImportance.Low, $"[MDP]     {m.DeclaringType.FullName}::{m.Name}");
+            }
+        }
+
+        private void LogAssemblyDefinitionCrcDetailed()
+        {
+            Log.LogMessage(MessageImportance.Low, $"[MDP] Assembly PE CRC inputs:");
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Assembly version          : {_assemblyBuilder.LastAssemblyVersion}");
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Native methods checksum   : 0x{_assemblyBuilder.LastNativeMethodsChecksum:X8}");
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Total PE size             : {_assemblyBuilder.LastTotalSize} bytes");
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Header region             : offset 0x0000, length {_assemblyBuilder.LastHeaderSize} bytes");
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   Body region               : offset 0x{_assemblyBuilder.LastHeaderSize:X4}, length {_assemblyBuilder.LastBodySize} bytes");
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   CRC32 body                : 0x{_assemblyBuilder.LastAssemblyCrc32:X8}");
+            Log.LogMessage(MessageImportance.Low, $"[MDP]   CRC32 header              : 0x{_assemblyBuilder.LastHeaderCrc32:X8}");
         }
 
         private void LogNativeCrcDetailed()

--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -26,7 +26,44 @@ namespace nanoFramework.Tools.MetadataProcessor
         private readonly bool _verbose;
         private readonly bool _isCoreLibrary;
 
+        private nanoAssemblyDefinition _lastHeader;
+
         public nanoTablesContext TablesContext => _tablesContext;
+
+        /// <summary>
+        /// Assembly body CRC32 from the most recent final write pass.
+        /// </summary>
+        public uint LastAssemblyCrc32 => _lastHeader?.LastAssemblyCrc32 ?? 0u;
+
+        /// <summary>
+        /// Header CRC32 from the most recent final write pass.
+        /// </summary>
+        public uint LastHeaderCrc32 => _lastHeader?.LastHeaderCrc32 ?? 0u;
+
+        /// <summary>
+        /// Total PE stream size from the most recent final write pass.
+        /// </summary>
+        public long LastTotalSize => _lastHeader?.LastTotalSize ?? 0L;
+
+        /// <summary>
+        /// Header region size hashed for the header CRC32.
+        /// </summary>
+        public long LastHeaderSize => _lastHeader?.LastHeaderSize ?? 0L;
+
+        /// <summary>
+        /// Body region size hashed for the assembly body CRC32.
+        /// </summary>
+        public long LastBodySize => _lastHeader?.LastBodySize ?? 0L;
+
+        /// <summary>
+        /// Native methods checksum embedded in the header.
+        /// </summary>
+        public uint LastNativeMethodsChecksum => _lastHeader?.LastNativeMethodsChecksum ?? 0u;
+
+        /// <summary>
+        /// Assembly version embedded in the header.
+        /// </summary>
+        public System.Version LastAssemblyVersion => _lastHeader?.LastAssemblyVersion;
 
         /// <summary>
         /// Creates new instance of <see cref="nanoAssemblyBuilder"/> object.
@@ -84,6 +121,8 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             binaryWriter.BaseStream.Seek(0, SeekOrigin.Begin);
             header.Write(binaryWriter, false);
+
+            _lastHeader = header;
         }
 
         /// <summary>

--- a/MetadataProcessor.Shared/nanoAssemblyDefinition.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyDefinition.cs
@@ -76,6 +76,41 @@ namespace nanoFramework.Tools.MetadataProcessor
         }
 
         /// <summary>
+        /// Assembly CRC32 computed during the last final write pass.
+        /// </summary>
+        public uint LastAssemblyCrc32 { get; private set; }
+
+        /// <summary>
+        /// Header CRC32 computed during the last final write pass.
+        /// </summary>
+        public uint LastHeaderCrc32 { get; private set; }
+
+        /// <summary>
+        /// Total PE stream length (bytes) at the time of the last final write pass.
+        /// </summary>
+        public long LastTotalSize { get; private set; }
+
+        /// <summary>
+        /// Header region size (bytes) hashed for the header CRC32.
+        /// </summary>
+        public long LastHeaderSize { get; private set; }
+
+        /// <summary>
+        /// Body region offset (= header size) and length hashed for the assembly body CRC32.
+        /// </summary>
+        public long LastBodySize { get; private set; }
+
+        /// <summary>
+        /// Native methods checksum value embedded in the header at the time of the last final write pass.
+        /// </summary>
+        public uint LastNativeMethodsChecksum { get; private set; }
+
+        /// <summary>
+        /// Assembly version embedded in the header at the time of the last final write pass.
+        /// </summary>
+        public System.Version LastAssemblyVersion { get; private set; }
+
+        /// <summary>
         /// Writes header information into output stream (w/o CRC and table offsets/paddings).
         /// </summary>
         /// <param name="writer">Binary writer with correct endianness.</param>
@@ -151,6 +186,13 @@ namespace nanoFramework.Tools.MetadataProcessor
                 // order matters!
                 // need to compute Assembly CRC32 before header CRC32
 
+                // capture inputs for logging
+                LastTotalSize = writer.BaseStream.Length;
+                LastHeaderSize = _headerSize;
+                LastBodySize = writer.BaseStream.Length - _headerSize;
+                LastNativeMethodsChecksum = _context.NativeMethodsCrc.CurrentCrc;
+                LastAssemblyVersion = _context.AssemblyDefinition.Name.Version;
+
                 // set writer position at Assembly CRC32 position
                 writer.BaseStream.Seek(c_AssemblyCrc32Position, SeekOrigin.Begin);
 
@@ -159,6 +201,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                     _headerSize,
                     writer.BaseStream.Length - _headerSize);
                 writer.WriteUInt32(assemblyCrc32);
+                LastAssemblyCrc32 = assemblyCrc32;
 
                 // set writer position at Header CRC32 position
                 writer.BaseStream.Seek(c_HeaderCrc32Position, SeekOrigin.Begin);
@@ -168,6 +211,7 @@ namespace nanoFramework.Tools.MetadataProcessor
                     0,
                     _headerSize);
                 writer.WriteUInt32(headerCrc32);
+                LastHeaderCrc32 = headerCrc32;
             }
         }
 


### PR DESCRIPTION
## Description
- Now includes list of all types, methods, fields, methodrefs, asssemblies and typerefs.
- Also added assembly CRC32 details.

## Motivation and Context
- Following #237.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [x] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
