### PR TITLE
Fix stub generation for delegate cache fields

### DIFF
--- a/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
+++ b/MetadataProcessor.Shared/nanoSkeletonGenerator.cs
@@ -588,7 +588,16 @@ namespace nanoFramework.Tools.MetadataProcessor.Core
             fixedFieldName = string.Empty;
             fieldWarning = string.Empty;
 
-            if (Regex.IsMatch(field.Name, @"<\w+>k__BackingField"))
+            // Roslyn-generated delegate cache fields: <N>__MethodName
+            // Strip angle brackets and number to create a valid C++ identifier
+            if (Regex.IsMatch(field.Name, @"^<\d+>__\w+"))
+            {
+                // Transform <0>__WorkingThread to __WorkingThread
+                fixedFieldName = Regex.Replace(field.Name, @"^<\d+>", "");
+                fieldWarning = $"// renamed compiler-generated field '{field.Name}'";
+            }
+            // Auto-property backing fields: <PropertyName>k__BackingField
+            else if (Regex.IsMatch(field.Name, @"<\w+>k__BackingField"))
             {
                 fixedFieldName = $"{field.Name.Replace("<", "").Replace(">k__BackingField", "")}";
                 fieldWarning = $"// renamed backing field '{field.Name}'";


### PR DESCRIPTION
## Description
- Now renaming the field to a valid C++ identifier.

## Motivation and Context

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoclr buildId 62379]

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
