### PR TITLE
Remove ExcludeClassByName parameter

### DIFF
--- a/MetadataProcessor.Console/Program.cs
+++ b/MetadataProcessor.Console/Program.cs
@@ -22,8 +22,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
             private AssemblyDefinition _assemblyDefinition;
             private nanoAssemblyBuilder _assemblyBuilder;
 
-            private List<string> _classNamesToExclude = new List<string>();
-
             internal string PeFileName;
 
             internal bool Verbose { get; set; }
@@ -57,7 +55,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                 {
                     if (Verbose) System.Console.WriteLine("Compiling assembly...");
 
-                    _assemblyBuilder = new nanoAssemblyBuilder(_assemblyDefinition, _classNamesToExclude, VerboseMinimize, isCoreLibrary);
+                    _assemblyBuilder = new nanoAssemblyBuilder(_assemblyDefinition, VerboseMinimize, isCoreLibrary);
 
                     using (var stream = File.Open(Path.ChangeExtension(fileName, "tmp"), FileMode.Create, FileAccess.ReadWrite))
                     using (var writer = new BinaryWriter(stream))
@@ -120,12 +118,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                 string assemblyFileName)
             {
                 _loadHints[assemblyName] = assemblyFileName;
-            }
-
-            public void AddClassToExclude(
-                string className)
-            {
-                _classNamesToExclude.Add(className);
             }
 
             public void GenerateSkeleton(
@@ -208,7 +200,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                     System.Console.WriteLine("-parse <path-to-assembly-file>                        Analyses .NET assembly.");
                     System.Console.WriteLine("-compile <path-to-PE-file> <isCoreLibrary>            Compiles an assembly into nanoCLR format and (true/false) if this it's a core library.");
                     System.Console.WriteLine("-loadHints <assembly-name> <path-to-assembly-file>    Loads one (or more) assembly file(s) as a dependency(ies).");
-                    System.Console.WriteLine("-excludeClassByName <class-name>                      Removes the class from an assembly.");
                     System.Console.WriteLine("-generateskeleton                                     Generate skeleton files with stubs to add native code for an assembly.");
                     System.Console.WriteLine("-generateDependency                                   Generates an XML file with the relationship between assemblies.");
                     System.Console.WriteLine("-verbose                                              Outputs each command before executing it.");
@@ -234,14 +225,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Console
                     md.Compile(md.PeFileName, isCoreLibrary);
 
                     i += 2;
-                }
-                else if (arg == "-excludeclassbyname" && i + 1 < args.Length)
-                {
-                    System.Console.WriteLine("*********************************************** WARNING *************************************************");
-                    System.Console.WriteLine("Use ExcludeTypeAttribute instead of passing this option. This will be removed in a future version of MDP.");
-                    System.Console.WriteLine("*********************************************************************************************************");
-
-                    md.AddClassToExclude(args[++i]);
                 }
                 else if (arg == "-verbose")
                 {

--- a/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
+++ b/MetadataProcessor.MsBuildTask/MetaDataProcessorTask.cs
@@ -34,9 +34,6 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
 
         public string LoadStrings { get; set; }
 
-        [Obsolete("Use ExcludeTypeAttribute instead of passing this parameter. This will be removed in a future version of MDP.")]
-        public ITaskItem[] ExcludeClassByName { get; set; }
-
         public ITaskItem[] ImportResources { get; set; }
 
         public string Parse { get; set; }
@@ -108,7 +105,6 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
         private nanoAssemblyBuilder _assemblyBuilder;
         private readonly IDictionary<string, string> _loadHints =
             new Dictionary<string, string>(StringComparer.Ordinal);
-        private readonly List<string> _classNamesToExclude = new List<string>();
         private string _nativeChecksum = "";
 
         #endregion
@@ -151,23 +147,6 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
                         _loadHints[assemblyName] = assemblyPath;
 
                         if (Verbose) Log.LogCommandLine(MessageImportance.Normal, $"Adding load hint: {assemblyName} @ '{assemblyPath}'");
-                    }
-                }
-
-                // class names to exclude from processing
-                if (ExcludeClassByName != null &&
-                    ExcludeClassByName.Any())
-                {
-                    if (Verbose) Log.LogCommandLine(MessageImportance.Normal, "Processing class exclusion list.");
-
-                    foreach (ITaskItem className in ExcludeClassByName)
-                    {
-                        _classNamesToExclude.Add(className.ToString());
-
-                        if (Verbose)
-                        {
-                            Log.LogCommandLine(MessageImportance.Normal, $"Adding '{className.ToString()}' to collection of classes to exclude");
-                        }
                     }
                 }
 
@@ -344,7 +323,6 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
 
                 _assemblyBuilder = new nanoAssemblyBuilder(
                     _assemblyDefinition,
-                    _classNamesToExclude,
                     Verbose,
                     IsCoreLibrary);
 
@@ -633,12 +611,6 @@ namespace nanoFramework.Tools.MetadataProcessor.MsBuildTask
             {
                 Log.LogMessage(MessageImportance.Low, $"[MDP]   - {typeName}");
             }
-        }
-
-        private void AddClassToExclude(
-            string className)
-        {
-            _classNamesToExclude.Add(className);
         }
 
         private void ExecuteGenerateSkeleton(

--- a/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
@@ -16,7 +16,7 @@ namespace nanoFramework.Tools.MetadataProcessor
     {
         internal readonly bool _verbose;
 
-        internal static HashSet<string> IgnoringAttributes { get; } = new HashSet<string>(StringComparer.Ordinal)
+        private static readonly HashSet<string> s_defaultIgnoringAttributes = new HashSet<string>(StringComparer.Ordinal)
             {
                 // Assembly-level attributes
                 "System.Reflection.AssemblyFileVersionAttribute",
@@ -70,6 +70,8 @@ namespace nanoFramework.Tools.MetadataProcessor
                 "System.STAThreadAttribute",
             };
 
+        internal static HashSet<string> IgnoringAttributes { get; private set; } = new HashSet<string>(s_defaultIgnoringAttributes, StringComparer.Ordinal);
+
         public nanoTablesContext(
             AssemblyDefinition assemblyDefinition,
             List<string> explicitTypesOrder,
@@ -82,6 +84,9 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             ClassNamesToExclude = new List<string>();
             _verbose = verbose;
+
+            // reset per-context ignored attributes from the immutable defaults
+            IgnoringAttributes = new HashSet<string>(s_defaultIgnoringAttributes, StringComparer.Ordinal);
 
             // add default types to exclude
             SetDefaultTypesToExclude();

--- a/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
+++ b/MetadataProcessor.Shared/Tables/nanoTablesContext.cs
@@ -73,7 +73,6 @@ namespace nanoFramework.Tools.MetadataProcessor
         public nanoTablesContext(
             AssemblyDefinition assemblyDefinition,
             List<string> explicitTypesOrder,
-            List<string> classNamesToExclude,
             ICustomStringSorter stringSorter,
             bool applyAttributesCompression,
             bool verbose,
@@ -81,33 +80,11 @@ namespace nanoFramework.Tools.MetadataProcessor
         {
             AssemblyDefinition = assemblyDefinition;
 
-            ClassNamesToExclude = classNamesToExclude;
+            ClassNamesToExclude = new List<string>();
             _verbose = verbose;
 
             // add default types to exclude
             SetDefaultTypesToExclude();
-
-            // check CustomAttributes against list of classes to exclude
-            foreach (CustomAttribute item in assemblyDefinition.CustomAttributes)
-            {
-                // add it to ignore list, if it's not already there
-                if ((ClassNamesToExclude.Contains(item.AttributeType.FullName) ||
-                     ClassNamesToExclude.Contains(item.AttributeType.DeclaringType?.FullName)) &&
-                    !(IgnoringAttributes.Contains(item.AttributeType.FullName) ||
-                      IgnoringAttributes.Contains(item.AttributeType.DeclaringType?.FullName)))
-                {
-                    IgnoringAttributes.Add(item.AttributeType.FullName);
-                }
-            }
-
-            // check ignoring attributes against ClassNamesToExclude 
-            foreach (string className in ClassNamesToExclude)
-            {
-                if (!IgnoringAttributes.Contains(className))
-                {
-                    IgnoringAttributes.Add(className);
-                }
-            }
 
             var mainModule = AssemblyDefinition.MainModule;
 
@@ -120,6 +97,10 @@ namespace nanoFramework.Tools.MetadataProcessor
             // get types to exclude from the types attributes
             ProcessTypesToExclude(types);
 
+            SyncIgnoredAttributesFromAssemblyAttributes(assemblyDefinition.CustomAttributes);
+            SyncIgnoredAttributesFromClassNamesToExclude();
+            LogClassNamesToExcludeIfVerbose();
+
             var fields = types
                 .SelectMany(item => GetOrderedFields(item.Fields.Where(field => !field.HasConstant)))
                 .ToList();
@@ -129,8 +110,7 @@ namespace nanoFramework.Tools.MetadataProcessor
             MethodDefinitionTable = new nanoMethodDefinitionTable(methods, this);
 
             NativeMethodsCrc = new NativeMethodsCrc(
-                assemblyDefinition,
-                ClassNamesToExclude);
+                assemblyDefinition);
 
             NativeMethodsCrc.UpdateCrc(TypeDefinitionTable);
 
@@ -526,6 +506,53 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         public static List<string> ClassNamesToExclude { get; private set; }
         public bool MinimizeComplete { get; internal set; } = false;
+
+        private static void SyncIgnoredAttributesFromAssemblyAttributes(IEnumerable<CustomAttribute> customAttributes)
+        {
+            foreach (CustomAttribute item in customAttributes)
+            {
+                // add it to ignore list, if it's not already there
+                if ((ClassNamesToExclude.Contains(item.AttributeType.FullName) ||
+                     ClassNamesToExclude.Contains(item.AttributeType.DeclaringType?.FullName)) &&
+                    !(IgnoringAttributes.Contains(item.AttributeType.FullName) ||
+                      IgnoringAttributes.Contains(item.AttributeType.DeclaringType?.FullName)))
+                {
+                    IgnoringAttributes.Add(item.AttributeType.FullName);
+                }
+            }
+        }
+
+        private static void SyncIgnoredAttributesFromClassNamesToExclude()
+        {
+            foreach (string className in ClassNamesToExclude)
+            {
+                if (!IgnoringAttributes.Contains(className))
+                {
+                    IgnoringAttributes.Add(className);
+                }
+            }
+        }
+
+        private void LogClassNamesToExcludeIfVerbose()
+        {
+            if (!_verbose)
+            {
+                return;
+            }
+
+            var excludedTypes = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (string className in ClassNamesToExclude)
+            {
+                if (string.IsNullOrWhiteSpace(className) ||
+                    !excludedTypes.Add(className))
+                {
+                    continue;
+                }
+
+                Console.WriteLine($"Adding '{className}' to collection of classes to exclude");
+            }
+        }
 
         private IEnumerable<Tuple<CustomAttribute, ICustomAttributeProvider>> GetAttributes(
             IEnumerable<ICustomAttributeProvider> types,

--- a/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
+++ b/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
@@ -22,18 +22,14 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         private readonly byte[] _name;
 
-        private readonly List<string> _classNamesToExclude;
-
         private int _methodsWithNativeImplementation = 0;
         private uint _currentCrc = 0;
         private readonly List<string> _crcLog = new List<string>();
 
         public NativeMethodsCrc(
-            AssemblyDefinition assembly,
-            List<string> classNamesToExclude)
+            AssemblyDefinition assembly)
         {
             _name = Encoding.ASCII.GetBytes(assembly.Name.Name);
-            _classNamesToExclude = classNamesToExclude;
         }
 
         /// <summary>
@@ -240,8 +236,8 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         private bool IsClassToExclude(TypeDefinition td)
         {
-            return (_classNamesToExclude.Contains(td.FullName) ||
-                    _classNamesToExclude.Contains(td.DeclaringType?.FullName));
+            return (nanoTablesContext.ClassNamesToExclude.Contains(td.FullName) ||
+                    nanoTablesContext.ClassNamesToExclude.Contains(td.DeclaringType?.FullName));
         }
 
         internal static string CleanupGenericName(string name)

--- a/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
+++ b/MetadataProcessor.Shared/Utility/NativeMethodsCrc.cs
@@ -3,6 +3,7 @@
 
 // Original work from Oleg Rakhmatulin.
 
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -22,6 +23,8 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         private readonly byte[] _name;
 
+        private readonly HashSet<string> _classNamesToExclude;
+
         private int _methodsWithNativeImplementation = 0;
         private uint _currentCrc = 0;
         private readonly List<string> _crcLog = new List<string>();
@@ -30,6 +33,12 @@ namespace nanoFramework.Tools.MetadataProcessor
             AssemblyDefinition assembly)
         {
             _name = Encoding.ASCII.GetBytes(assembly.Name.Name);
+
+            // Snapshot the current exclusion list so this instance is isolated
+            // from later nanoTablesContext instances that may replace the static.
+            _classNamesToExclude = nanoTablesContext.ClassNamesToExclude != null
+                ? new HashSet<string>(nanoTablesContext.ClassNamesToExclude, StringComparer.Ordinal)
+                : new HashSet<string>(StringComparer.Ordinal);
         }
 
         /// <summary>
@@ -236,8 +245,8 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         private bool IsClassToExclude(TypeDefinition td)
         {
-            return (nanoTablesContext.ClassNamesToExclude.Contains(td.FullName) ||
-                    nanoTablesContext.ClassNamesToExclude.Contains(td.DeclaringType?.FullName));
+            return (_classNamesToExclude.Contains(td.FullName) ||
+                    _classNamesToExclude.Contains(td.DeclaringType?.FullName));
         }
 
         internal static string CleanupGenericName(string name)

--- a/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
+++ b/MetadataProcessor.Shared/nanoAssemblyBuilder.cs
@@ -76,7 +76,6 @@ namespace nanoFramework.Tools.MetadataProcessor
         /// </param>
         public nanoAssemblyBuilder(
             AssemblyDefinition assemblyDefinition,
-            List<string> classNamesToExclude,
             bool verbose,
             bool isCoreLibrary = false,
             List<string> explicitTypesOrder = null,
@@ -86,7 +85,6 @@ namespace nanoFramework.Tools.MetadataProcessor
             _tablesContext = new nanoTablesContext(
                 assemblyDefinition,
                 explicitTypesOrder,
-                classNamesToExclude,
                 stringSorter,
                 applyAttributesCompression,
                 verbose,

--- a/MetadataProcessor.Tests/Core/Extensions/TypeDefinitionExtensionsTests.cs
+++ b/MetadataProcessor.Tests/Core/Extensions/TypeDefinitionExtensionsTests.cs
@@ -110,8 +110,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Extensions
             nanoTablesContext nanoTablesContext = new nanoTablesContext(
                 assemblyDefinition,
                 null,
-                // adding this here, equivalent to the NFMDP_PE_ExcludeClassByName project property
-                new List<string>() { "TestNFClassLibrary.IAmATypeToExclude" },
                 null,
                 false,
                 false,
@@ -128,7 +126,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Extensions
             Assert.IsNotNull(testNFLibraryModule.Types.FirstOrDefault(i => i.FullName == "TestNFClassLibrary.IAmATypeToExclude"), "TestNFClassLibrary.IAmATypeToExclude type not found");
 
             // test if <TestNFClassLibrary.IAmATypeToExclude> type is to be excluded
-            // this is being excluded with the NFMDP_PE_ExcludeClassByName project property
+            // this is being excluded with the ExcludeType attribute
             Assert.IsTrue(testNFLibraryModule.Types.First(i => i.FullName == "TestNFClassLibrary.IAmATypeToExclude").IsToExclude(), "TestNFClassLibrary.IAmATypeToExclude type is not listed to be excluded, when it should");
 
             // test if <TestNFClassLibrary.IAmAlsoATypeToExclude> type is present
@@ -155,7 +153,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Extensions
             nanoTablesContext context = new nanoTablesContext(
                 mscorlibAssemblyDefinition,
                 null,
-                new List<string>(),
                 null,
                 false,
                 false,

--- a/MetadataProcessor.Tests/Core/StubsGenerationTests.cs
+++ b/MetadataProcessor.Tests/Core/StubsGenerationTests.cs
@@ -267,12 +267,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core
                     "mscorlib.dll")
             };
 
-            // class names to exclude from processing
-            var classNamesToExclude = new List<string>
-            {
-                "THIS_NAME_DOES_NOT_EXIST_IN_THE_PROJECT"
-            };
-
             // Conpile StubsGenerationNFApp
             string stubsGenerationFileToParse = TestObjectHelper.StubsGenerationNFAppFullPath;
             string stubsGenerationFileToCompile = Path.ChangeExtension(stubsGenerationFileToParse, "pe");
@@ -286,7 +280,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core
                 stubsGenerationFileToParse,
                 new ReaderParameters { AssemblyResolver = new LoadHintsAssemblyResolver(loadHints) });
 
-            nanoAssemblyBuilder assemblyBuilder = new nanoAssemblyBuilder(assemblyDefinition, classNamesToExclude, false);
+            nanoAssemblyBuilder assemblyBuilder = new nanoAssemblyBuilder(assemblyDefinition, false);
 
             using (FileStream stream = File.Open(
                        Path.ChangeExtension(stubsGenerationFileToCompile, "tmp"),
@@ -334,7 +328,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core
 
             assemblyBuilder = new nanoAssemblyBuilder(
                 assemblyDefinition,
-                new List<string>(),
                 false);
 
             using (FileStream stream = File.Open(

--- a/MetadataProcessor.Tests/Core/Tables/nanoAttributesTableTests.cs
+++ b/MetadataProcessor.Tests/Core/Tables/nanoAttributesTableTests.cs
@@ -184,7 +184,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
         public void TestCodeAnalysisAttributes()
         {
             var assemblyDefinition = TestObjectHelper.GetTestNFAppAssemblyDefinitionWithLoadHints();
-            var assemblyBuilder = new nanoAssemblyBuilder(assemblyDefinition, new List<string>(), false);
+            var assemblyBuilder = new nanoAssemblyBuilder(assemblyDefinition, false);
 
             using (var stream = File.Open(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite))
             using (var writer = new BinaryWriter(stream))

--- a/MetadataProcessor.Tests/Core/Tables/nanoSignaturesTableTests.cs
+++ b/MetadataProcessor.Tests/Core/Tables/nanoSignaturesTableTests.cs
@@ -30,7 +30,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
             nanoTablesContext context = new nanoTablesContext(
                 mscorlibAssemblyDefinition,
                 null,
-                new List<string>(),
                 null,
                 false,
                 false,

--- a/MetadataProcessor.Tests/Core/Utility/NativeMethodsCrcTests.cs
+++ b/MetadataProcessor.Tests/Core/Utility/NativeMethodsCrcTests.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Mono.Cecil;
 
@@ -132,7 +131,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
         {
             var assemblyDefinition = TestObjectHelper.GetTestNFAppAssemblyDefinition();
 
-            var iut = new NativeMethodsCrc(assemblyDefinition, new List<string>());
+            var iut = new NativeMethodsCrc(assemblyDefinition);
 
             // test
             Assert.AreEqual((uint)0, iut.CurrentCrc);
@@ -146,7 +145,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
             var nonExternMethodDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllDummyMethodDefinition(typeDefinition);
             var externMethodDefinition = TestObjectHelper.GetTestNFAppOneClassOverAllDummyExternMethodDefinition(typeDefinition);
 
-            var iut = new NativeMethodsCrc(assemblyDefinition, new List<string>());
+            var iut = new NativeMethodsCrc(assemblyDefinition);
 
             // test
             iut.UpdateCrc(nonExternMethodDefinition);
@@ -177,7 +176,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Utility
         {
             var context = TestObjectHelper.GetTestNFAppNanoTablesContext();
 
-            var iut = new NativeMethodsCrc(context.AssemblyDefinition, new List<string>());
+            var iut = new NativeMethodsCrc(context.AssemblyDefinition);
 
             // test
             iut.UpdateCrc(context.TypeDefinitionTable);

--- a/MetadataProcessor.Tests/MsbuildTask/MsbuildTaskTests.cs
+++ b/MetadataProcessor.Tests/MsbuildTask/MsbuildTaskTests.cs
@@ -22,27 +22,19 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.MsbuildTask
                 ["mscorlib"] = Path.Combine(Directory.GetParent(TestObjectHelper.NFAppFullPath).FullName, "mscorlib.dll")
             };
 
-            // class names to exclude from processing
-            var classNamesToExclude = new List<string>
-            {
-                "THIS_NAME_DOES_NOT_EXIST_IN_THE_PROJECT"
-            };
-
             var fileToParse = TestObjectHelper.NFAppFullPath;
             var fileToCompiler = Path.ChangeExtension(fileToParse, "pe");
 
-            ProcessAssembly(loadHints, classNamesToExclude, fileToParse, fileToCompiler);
+            ProcessAssembly(loadHints, fileToParse, fileToCompiler);
         }
 
         private void ProcessAssembly(
             Dictionary<string, string> loadHints,
-            List<string> classNamesToExclude,
             string fileToParse,
             string fileToCompile)
         {
             ProcessAssembly(
                 loadHints,
-                classNamesToExclude,
                 fileToParse,
                 fileToCompile,
                 null,
@@ -55,7 +47,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.MsbuildTask
 
         private void ProcessAssembly(
             Dictionary<string, string> loadHints,
-            List<string> classNamesToExclude,
             string fileToParse,
             string fileToCompile,
             string GenerateSkeletonFile,
@@ -80,7 +71,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.MsbuildTask
             // compile
             var _assemblyBuilder = new nanoAssemblyBuilder(
                 assemblyDefinition,
-                classNamesToExclude,
                 true,
                 false);
 

--- a/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmATypeToExclude.cs
+++ b/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/IAmATypeToExclude.cs
@@ -1,9 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Runtime.CompilerServices;
+
 namespace TestNFClassLibrary
 {
-    // this type does nothing, its here to test the backwards compatibility with NFMDP_PE_ExcludeClassByName project property to exclude types
+    // this type does nothing; it is used to test type exclusion via ExcludeTypeAttribute.
+    [ExcludeType]
     public class IAmATypeToExclude
     {
     }

--- a/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/TestNFClassLibrary.nfproj
+++ b/MetadataProcessor.Tests/TestNFClassLibrary/TestNFClassLibrary/TestNFClassLibrary.nfproj
@@ -28,11 +28,6 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <NFMDP_PE_ExcludeClassByName Include="TestNFClassLibrary.IAmATypeToExclude">
-      <InProject>false</InProject>
-    </NFMDP_PE_ExcludeClassByName>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\mscorlib\nanoFramework.CoreLibrary\CoreLibrary.nfproj" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />

--- a/MetadataProcessor.Tests/TestObjectHelper.cs
+++ b/MetadataProcessor.Tests/TestObjectHelper.cs
@@ -34,7 +34,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests
             ret = new nanoTablesContext(
                 assemblyDefinition,
                 null,
-                new List<string>(),
                 null,
                 false,
                 false,
@@ -50,7 +49,6 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests
             return new nanoTablesContext(
                 assemblyDefinition,
                 null,
-                new List<string>(),
                 null,
                 false,
                 false,


### PR DESCRIPTION
## Description
- Adjust code accordingly.
- Adjust unit tests.
- Also removed it from console app.

## Motivation and Context
- This parameter has been marked as obsolete for quite some time. Now feels like a good time to make this breaking change.
- Related with nanoframework/nf-Visual-Studio-extension#934

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoclr buildId 63190].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [x] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
