### PR TITLE
Fix mapping of (s)byte in FixTypeNames

### DIFF
--- a/MetadataProcessor.Shared/Utility/FixTypeNames.cs
+++ b/MetadataProcessor.Shared/Utility/FixTypeNames.cs
@@ -8,7 +8,7 @@ namespace nanoFramework.Tools.MetadataProcessor
         internal static string FixTypeNames(string name)
         {
             // This is used to remedy the wrong output from Cecil.Mono
-            // Reported jbevain/cecil#715 
+            // Reported jbevain/cecil/issues/715
             // OK to remove if implemented
 
             // following II.23.2.16 Short form signatures
@@ -19,8 +19,8 @@ namespace nanoFramework.Tools.MetadataProcessor
             fixedName = fixedName.Replace("System.Void", "void");
             fixedName = fixedName.Replace("System.Boolean", "bool");
             fixedName = fixedName.Replace("System.Char", "char");
-            fixedName = fixedName.Replace("System.Byte", "int8");
-            fixedName = fixedName.Replace("System.Sbyte", "uint8");
+            fixedName = fixedName.Replace("System.Byte", "uint8");
+            fixedName = fixedName.Replace("System.Sbyte", "int8");
             fixedName = fixedName.Replace("System.Int16", "int16");
             fixedName = fixedName.Replace("System.UInt16", "uint16");
             fixedName = fixedName.Replace("System.Int32", "int32");


### PR DESCRIPTION
## Description
- Fix mapping of (s)byte in FixTypeNames.
- Also improve link to GitHub issue.

## Motivation and Context
- Found when debugging generics display in VS extension.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoclr buildId 65540].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [ ] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [ ] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [ ] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
