### PR TITLE
Improvements in pdbx

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -142,6 +142,15 @@ Several code sections must remain in sync with external repositories. These are 
 
 When modifying code near these tags, **do not change the semantics** without coordinating with the corresponding external code.
 
+### Documentation policy
+
+Source comments stay minimal — one line flagging a non-obvious invariant, with
+a `see <Dir>/CLAUDE.md "Section Title"` pointer where deeper reasoning exists.
+Deductions, empirical findings, and design rationale belong in a `CLAUDE.md`
+next to the source it documents, not as comment blocks in `.cs` files. See
+`MetadataProcessor.Shared/Pdbx/CLAUDE.md` for an example (PDBX `TypeSpec`
+generic-argument representation).
+
 ---
 
 ## Architecture: How the Metadata Processor Works

--- a/MetadataProcessor.Shared/Pdbx/CLAUDE.md
+++ b/MetadataProcessor.Shared/Pdbx/CLAUDE.md
@@ -1,0 +1,103 @@
+# Pdbx TypeSpec generic-argument representation
+
+Companion to `Pdbx.cs` / `PdbxFileHelpers.cs`. Captures the reasoning behind
+`TypeSpec.GenericArguments` so the source files can stay terse.
+
+**Documentation policy:** source comments in this directory stay minimal —
+one line flagging a non-obvious invariant at the point it matters. Deductions,
+empirical findings, and "why not the other approach" belong here, with a
+`see Pdbx/CLAUDE.md "Section Title"` pointer left in the code.
+
+---
+
+## 1. Why arguments are addressed by NanoCLR token, not CLR token
+
+`TypeSpec.Token.CLRToken` is fabricated (`new MetadataToken(TokenType.TypeSpec,
+nanoToken)`), not `item.MetadataToken`. Verified empirically against
+`Mono.Cecil.dll` directly (small standalone harness, not the MDP pipeline):
+
+| Where the generic instance appears | `TypeReference.MetadataToken.RID` |
+|---|---|
+| Field type only | `0` |
+| Method return type only | `0` |
+| Explicit interface implementation | real |
+| `MemberRef` declaring type / IL operand | real |
+
+Per ECMA-335, a real PE `TypeSpec` table row exists only when something needs
+a token for that instantiation (an IL operand, or a `MemberRef`'s `Class`
+column). A closed generic type used only as a field's or method's declared
+type is encoded inline in the signature blob — Cecil constructs a
+`GenericInstanceType` for it with no backing table row, so `MetadataToken`
+is RID 0.
+
+So every reference in this model — `GenericTypeDef`, `TypeSpecArg.TypeToken`,
+`TypeSpecArg.GenericParamToken` — is a **NanoCLR** token, the one
+`nanoTypeSpecificationsTable`/`nanoGenericParamTable` themselves assign. The
+wire protocol (`Debugging_Resolve_Type`) already resolves these; nothing on
+the CLR/firmware side had to change for this feature.
+
+## 2. Why classes get a name fallback (`ClassName`, `GenericTypeDefName`)
+
+This model has no `TypeRef` table. A NanoCLR TypeDef token only exists for a
+class declared in the assembly currently being processed — there is no way
+to address a class declared in a *different* assembly by token here. Cecil's
+own `TypeReference.FullName` (never passed through `FixTypeNames`, which
+rewrites primitive names to ILAsm short forms and would corrupt an ordinary
+class name) is recorded alongside the token as a name-based fallback, mirroring
+`Class.Name`. The consumer resolves the token first (unambiguous, cheap) and
+falls back to a cross-assembly by-name lookup only when it's null.
+
+## 3. Bare generic parameters (VAR/MVAR) as arguments
+
+`GenParamContainer<T>.Slot`, typed `Pair<T,int>`, is common — any generic
+type that uses another generic type internally, closing over its own type
+parameter. `GenericInstanceType.GenericArguments` can contain a bare
+`GenericParameter` (`T`) instead of a closed type. Confirmed empirically: 11
+occurrences in one 3-member test class; `GenericParameter is TypeSpecification`
+is `False` (siblings under `TypeReference`, not a subtype); `.Resolve()`
+returns `null` rather than throwing.
+
+Falling through to the ordinary-class branch for this case doesn't crash —
+`ResolveLocalClassToken` degrades safely — but it records a meaningless,
+unqualified `ClassName` ("T") with no token, losing which parameter it is and
+whose type or method declares it. `TypeSpecArg.IsGenericParameter` +
+`GenericParamToken`/`GenericParamIsMethodOwned`/`GenericParamPosition` address
+it directly instead: the parameter's own declaration already has a real,
+stable Cecil `MetadataToken` (declarations are real table rows, unlike
+generic-instance arguments — see §1), resolved via the existing
+`nanoGenericParamTable.TryGetParameterId`.
+
+Verified against real Cecil data that type-owned and method-owned parameters
+land in the same `GenericArguments` list with distinct tokens even at the same
+`Position` (e.g. `Pair<U,T>` inside a method `Wrap<U>` on `Container<T>`: `U`
+is MVAR position 0 with one token, `T` is VAR position 0 with a different one)
+— `GenericParamIsMethodOwned` is what disambiguates them.
+
+Tests: `TestNFApp/GenericParameterArgumentTypeSpecTests.cs` (fixture, both
+cases) and `Core/Tables/nanoTypeSpecArgGenericParameterTests.cs` (assertions).
+
+## 4. Consumer side: `CorDebugTypeParameter` (vs-extension.shared/CorDebug/CorDebugType.cs)
+
+The CLR reports a generic instance as `DATATYPE_CLASS`/`DATATYPE_VALUETYPE`
+with `HB_GenericInstance` set, `m_td` the open TypeDef and `m_ts` the closed
+TypeSpec. `CorDebugTypeParameter.FromRuntimeValue` resolves `m_ts` to its
+`Pdbx.TypeSpec` and walks `GenericArguments`, resolving each against the
+*owning* assembly (the one that owns the TypeSpec, not the caller's) since
+`TypeToken`/`GenericParamToken` are local-assembly tokens (§1).
+
+Fails closed on the whole instance if *any* argument can't be resolved,
+rather than rendering a name with holes — the caller (`EnumerateTypeParameters`)
+then returns `E_NOTIMPL`, which is exactly the behaviour that shipped before
+this feature, so an unresolvable instance still renders as the open type.
+
+## 5. `ResolveLocalClassToken` and unresolvable foreign assemblies
+
+`TypeReference.Resolve()` throws `Mono.Cecil.AssemblyResolutionException`
+when the type's declaring assembly can't be located by the resolver (not
+restored, not on the search path, ...). `BuildTypeSpecArg` calls this for
+every non-primitive, non-generic-parameter argument encountered anywhere in
+the assembly, so an unresolvable foreign reference must not take down the
+whole pdbx generation — it is exactly the "not a local TypeDef" case
+(`ResolveLocalClassToken` already returns `null` for a class it can resolve
+but that isn't registered locally), so the exception is caught and treated
+the same way.

--- a/MetadataProcessor.Shared/Pdbx/CLAUDE.md
+++ b/MetadataProcessor.Shared/Pdbx/CLAUDE.md
@@ -62,16 +62,26 @@ Falling through to the ordinary-class branch for this case doesn't crash —
 unqualified `ClassName` ("T") with no token, losing which parameter it is and
 whose type or method declares it. `TypeSpecArg.IsGenericParameter` +
 `GenericParamToken`/`GenericParamIsMethodOwned`/`GenericParamPosition` address
-it directly instead: the parameter's own declaration already has a real,
-stable Cecil `MetadataToken` (declarations are real table rows, unlike
-generic-instance arguments — see §1), resolved via the existing
-`nanoGenericParamTable.TryGetParameterId`.
+it directly instead, resolved via `nanoGenericParamTable.TryGetParameterId`.
 
-Verified against real Cecil data that type-owned and method-owned parameters
-land in the same `GenericArguments` list with distinct tokens even at the same
-`Position` (e.g. `Pair<U,T>` inside a method `Wrap<U>` on `Container<T>`: `U`
-is MVAR position 0 with one token, `T` is VAR position 0 with a different one)
-— `GenericParamIsMethodOwned` is what disambiguates them.
+**`Owner`/`MetadataToken` are not reliable on the `GenericParameter` object
+itself — use `.Type` (`GenericParameterType.Method` vs `.Type`) for VAR/MVAR,
+never `Owner is MethodDefinition`.** Verified by comparing a fresh Cecil parse
+of a test assembly against what `nanoTypeSpecificationsTable` actually stores
+after the full `Write→Minimize→Write` pipeline: a parameter reached via a
+*field* type (e.g. `Container<T>.Slot`'s `T`) keeps its real declaration
+(`Owner` a `TypeDefinition`, a valid `MetadataToken` RID) both times. The same
+kind of parameter reached via a *generic method's return type* (a
+`GenericInstanceMethod` call site, e.g. `Wrap<U>`'s `Pair<U,T>`) is stored as a
+bare shape by the time `BuildTypeSpecArg` sees it: `Owner` null,
+`MetadataToken` RID 0, for *both* its VAR and MVAR arguments — even the VAR
+one, despite the identical `T` resolving fine via the field-type path. `.Type`
+survives this degradation; `Owner`/`MetadataToken` do not. So
+`GenericParamToken` legitimately stays null for this shape on both arguments,
+including the type-owned one — `BuildTypeSpecArg` has no way to recover it
+(it never sees which method/type this shape came from), and that's fine: the
+consumer only needs `IsGenericParameter` + `GenericParamIsMethodOwned` +
+`GenericParamPosition` to fail closed correctly (§4).
 
 Tests: `TestNFApp/GenericParameterArgumentTypeSpecTests.cs` (fixture, both
 cases) and `Core/Tables/nanoTypeSpecArgGenericParameterTests.cs` (assertions).

--- a/MetadataProcessor.Shared/Pdbx/Pdbx.cs
+++ b/MetadataProcessor.Shared/Pdbx/Pdbx.cs
@@ -86,11 +86,12 @@ namespace nanoFramework.Tools.MetadataProcessor
 
         public List<Member> Members { get; set; }
 
-        /// <summary>
-        /// The open generic TypeDef this TypeSpec closes over (for example <c>Box`1</c> for
-        /// <c>Box&lt;int&gt;</c>). Only set when <see cref="IsGenericInstance"/> is <see langword="true"/>.
-        /// </summary>
+        // NanoCLR TypeDef token of the open generic (e.g. Box`1), local assembly only.
+        // See Pdbx/CLAUDE.md "Why classes get a name fallback".
         public Token GenericTypeDef { get; set; }
+
+        // Cross-assembly fallback for GenericTypeDef: Cecil's unmodified FullName.
+        public string GenericTypeDefName { get; set; }
 
         /// <summary>
         /// The type arguments that close <see cref="GenericTypeDef"/>, in declaration order. Only set when
@@ -99,40 +100,37 @@ namespace nanoFramework.Tools.MetadataProcessor
         public List<TypeSpecArg> GenericArguments { get; set; }
     }
 
-    /// <summary>
-    /// One type argument of a closed generic instance (see <see cref="TypeSpec.GenericArguments"/>).
-    /// Every reference here is a NanoCLR token, never a CLR one -- CLR tokens for TypeSpec entries are not
-    /// reliably available (a generic instance used only as a field type or a method return type has no
-    /// backing PE metadata row, so Mono.Cecil reports RID 0 for it), while the NanoCLR token is always the
-    /// one this table itself assigns and is what the wire protocol (Debugging_Resolve_Type) already resolves.
-    /// </summary>
+    // One type argument of a closed generic instance (TypeSpec.GenericArguments).
+    // See Pdbx/CLAUDE.md "Why arguments are addressed by NanoCLR token, not CLR token".
     public partial class TypeSpecArg
     {
         public bool IsPrimitive { get; set; }
 
-        /// <summary>
-        /// Set only when <see cref="IsPrimitive"/> is <see langword="true"/>. The name of a
-        /// <c>NanoCLRDataType</c> member (for example <c>DATATYPE_I4</c>).
-        /// </summary>
+        // Set when IsPrimitive: a NanoCLRDataType member name (e.g. "DATATYPE_I4").
         public string PrimitiveType { get; set; }
 
-        /// <summary>
-        /// Set only when <see cref="IsPrimitive"/> is <see langword="false"/>. The NanoCLR TypeDef token of
-        /// a class declared in the same assembly as this TypeSpec, or the NanoCLR TypeSpec token of a nested
-        /// generic instance (also always local to this assembly). <see langword="null"/> when the argument
-        /// is an ordinary class declared in a different assembly -- there is no TypeRef entry in this model
-        /// to address it by token, so <see cref="ClassName"/> is the only way to resolve it in that case.
-        /// </summary>
+        // Local-assembly NanoCLR token (TypeDef or nested TypeSpec). Null for a foreign class --
+        // see ClassName -- or for a generic-parameter argument -- see IsGenericParameter.
         public Token TypeToken { get; set; }
 
-        /// <summary>
-        /// Set only for ordinary (non-generic-instance) class arguments: Cecil's own
-        /// <c>TypeReference.FullName</c>, exactly as recorded in <see cref="Class.Name"/> for that class --
-        /// never passed through the FixTypeNames helper. Used to resolve the class by name (across every
-        /// loaded assembly) when <see cref="TypeToken"/> could not be resolved because the class is declared
-        /// in a different assembly than this TypeSpec.
-        /// </summary>
+        // Cross-assembly fallback for TypeToken: Cecil's unmodified FullName.
         public string ClassName { get; set; }
+
+        // True for a bare VAR/MVAR argument (e.g. T in Pair<T,int> inside the generic type that
+        // declares T) rather than a closed type. TypeToken/ClassName are not used in this case.
+        // See Pdbx/CLAUDE.md "Bare generic parameters (VAR/MVAR) as arguments".
+        public bool IsGenericParameter { get; set; }
+
+        // Set when IsGenericParameter: the NanoCLR TBL_GenericParam token of the parameter's own
+        // declaration.
+        public Token GenericParamToken { get; set; }
+
+        // Set when IsGenericParameter: true for a method type parameter (MVAR), false for a type
+        // parameter (VAR).
+        public bool GenericParamIsMethodOwned { get; set; }
+
+        // Set when IsGenericParameter: zero-based position on its owner.
+        public int GenericParamPosition { get; set; }
     }
 
     public partial class Member

--- a/MetadataProcessor.Shared/Pdbx/Pdbx.cs
+++ b/MetadataProcessor.Shared/Pdbx/Pdbx.cs
@@ -93,10 +93,7 @@ namespace nanoFramework.Tools.MetadataProcessor
         // Cross-assembly fallback for GenericTypeDef: Cecil's unmodified FullName.
         public string GenericTypeDefName { get; set; }
 
-        /// <summary>
-        /// The type arguments that close <see cref="GenericTypeDef"/>, in declaration order. Only set when
-        /// <see cref="IsGenericInstance"/> is <see langword="true"/>.
-        /// </summary>
+        // Type arguments that close GenericTypeDef, in declaration order.
         public List<TypeSpecArg> GenericArguments { get; set; }
     }
 

--- a/MetadataProcessor.Shared/Pdbx/Pdbx.cs
+++ b/MetadataProcessor.Shared/Pdbx/Pdbx.cs
@@ -85,6 +85,54 @@ namespace nanoFramework.Tools.MetadataProcessor
         public bool IsGenericInstance { get; set; } = false;
 
         public List<Member> Members { get; set; }
+
+        /// <summary>
+        /// The open generic TypeDef this TypeSpec closes over (for example <c>Box`1</c> for
+        /// <c>Box&lt;int&gt;</c>). Only set when <see cref="IsGenericInstance"/> is <see langword="true"/>.
+        /// </summary>
+        public Token GenericTypeDef { get; set; }
+
+        /// <summary>
+        /// The type arguments that close <see cref="GenericTypeDef"/>, in declaration order. Only set when
+        /// <see cref="IsGenericInstance"/> is <see langword="true"/>.
+        /// </summary>
+        public List<TypeSpecArg> GenericArguments { get; set; }
+    }
+
+    /// <summary>
+    /// One type argument of a closed generic instance (see <see cref="TypeSpec.GenericArguments"/>).
+    /// Every reference here is a NanoCLR token, never a CLR one -- CLR tokens for TypeSpec entries are not
+    /// reliably available (a generic instance used only as a field type or a method return type has no
+    /// backing PE metadata row, so Mono.Cecil reports RID 0 for it), while the NanoCLR token is always the
+    /// one this table itself assigns and is what the wire protocol (Debugging_Resolve_Type) already resolves.
+    /// </summary>
+    public partial class TypeSpecArg
+    {
+        public bool IsPrimitive { get; set; }
+
+        /// <summary>
+        /// Set only when <see cref="IsPrimitive"/> is <see langword="true"/>. The name of a
+        /// <c>NanoCLRDataType</c> member (for example <c>DATATYPE_I4</c>).
+        /// </summary>
+        public string PrimitiveType { get; set; }
+
+        /// <summary>
+        /// Set only when <see cref="IsPrimitive"/> is <see langword="false"/>. The NanoCLR TypeDef token of
+        /// a class declared in the same assembly as this TypeSpec, or the NanoCLR TypeSpec token of a nested
+        /// generic instance (also always local to this assembly). <see langword="null"/> when the argument
+        /// is an ordinary class declared in a different assembly -- there is no TypeRef entry in this model
+        /// to address it by token, so <see cref="ClassName"/> is the only way to resolve it in that case.
+        /// </summary>
+        public Token TypeToken { get; set; }
+
+        /// <summary>
+        /// Set only for ordinary (non-generic-instance) class arguments: Cecil's own
+        /// <c>TypeReference.FullName</c>, exactly as recorded in <see cref="Class.Name"/> for that class --
+        /// never passed through the FixTypeNames helper. Used to resolve the class by name (across every
+        /// loaded assembly) when <see cref="TypeToken"/> could not be resolved because the class is declared
+        /// in a different assembly than this TypeSpec.
+        /// </summary>
+        public string ClassName { get; set; }
     }
 
     public partial class Member

--- a/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
+++ b/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
@@ -219,6 +219,19 @@ namespace nanoFramework.Tools.MetadataProcessor
 
             if (item.IsGenericInstance)
             {
+                var genericInstance = (GenericInstanceType)item;
+
+                // ElementType is always the open generic TypeDef (never itself a TypeSpecification), so the
+                // local-class resolver is enough here. When it is declared in a different assembly this is left null.
+                GenericTypeDef = ResolveLocalClassToken(context, genericInstance.ElementType);
+
+                GenericArguments = new List<TypeSpecArg>();
+
+                foreach (var argument in genericInstance.GenericArguments)
+                {
+                    GenericArguments.Add(BuildTypeSpecArg(context, argument));
+                }
+
                 foreach (var mr in context.MethodReferencesTable.Items)
                 {
                     if (context.TypeSpecificationsTable.TryGetTypeReferenceId(mr.DeclaringType, out ushort referenceId) &&
@@ -243,6 +256,82 @@ namespace nanoFramework.Tools.MetadataProcessor
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Builds the structured description of one generic type argument: a primitive element type, or the
+        /// NanoCLR token of a class (TypeDef/TypeRef) or nested TypeSpec. Returns an argument with neither
+        /// <see cref="TypeSpecArg.PrimitiveType"/> nor <see cref="TypeSpecArg.TypeToken"/> set when the
+        /// argument cannot be resolved to a token (for example an unresolved generic parameter) -- callers
+        /// are expected to treat that as "cannot fully describe this instance".
+        /// </summary>
+        private static TypeSpecArg BuildTypeSpecArg(nanoTablesContext context, TypeReference argumentType)
+        {
+            var arg = new TypeSpecArg();
+
+            if (nanoSignaturesTable.PrimitiveTypes.TryGetValue(argumentType.FullName, out NanoCLRDataType dataType))
+            {
+                arg.IsPrimitive = true;
+                arg.PrimitiveType = dataType.ToString();
+
+                return arg;
+            }
+
+            arg.IsPrimitive = false;
+
+            if (argumentType is TypeSpecification)
+            {
+                // nested generic instance (or array/pointer/by-ref type) -- only describable through its
+                // own TypeSpec entry, which is always local to this assembly's TypeSpec table.
+                arg.TypeToken = ResolveTypeSpecToken(context, argumentType);
+
+                return arg;
+            }
+
+            // Ordinary class. Prefer a NanoCLR TypeDef token: it is unambiguous and cheap to resolve, but it
+            // only exists when the class is declared in the assembly currently being processed -- the pdbx
+            // model has no TypeRef list, so there is no way for the debugger to chase a foreign-assembly
+            // TypeRef token back to a class.
+            arg.ClassName = argumentType.FullName;
+            arg.TypeToken = ResolveLocalClassToken(context, argumentType);
+
+            return arg;
+        }
+
+        /// <summary>
+        /// Resolves the NanoCLR token of a nested TypeSpec entry (a generic instance, array, pointer, or
+        /// by-ref type -- anything Mono.Cecil models as a <see cref="TypeSpecification"/>).
+        /// </summary>
+        /// <returns>The token, or <see langword="null"/> when the type is not registered in this assembly TypeSpec table.</returns>
+        private static Token ResolveTypeSpecToken(nanoTablesContext context, TypeReference typeSpecification)
+        {
+            if (context.TypeSpecificationsTable.TryGetTypeReferenceId(typeSpecification, out ushort typeSpecId))
+            {
+                var clrToken = new MetadataToken(TokenType.TypeSpec, typeSpecId);
+
+                return new Token(clrToken, NanoClrTable.TBL_TypeSpec.ToNanoTokenType() | typeSpecId);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Resolves the NanoCLR TypeDef token of a class, but only when it is declared in the assembly
+        /// currently being processed (see the remarks on <see cref="BuildTypeSpecArg"/> for why an external
+        /// class cannot be addressed by token here).
+        /// </summary>
+        /// <returns>The token, or <see langword="null"/> when the type is not a local TypeDef.</returns>
+        private static Token ResolveLocalClassToken(nanoTablesContext context, TypeReference typeReference)
+        {
+            TypeDefinition typeDefinition = typeReference as TypeDefinition ?? typeReference.Resolve();
+
+            if (typeDefinition != null &&
+                context.TypeDefinitionTable.TryGetTypeReferenceId(typeDefinition, out ushort typeDefId))
+            {
+                return new Token(typeDefinition.MetadataToken, NanoClrTable.TBL_TypeDef.ToNanoTokenType() | typeDefId);
+            }
+
+            return null;
         }
     }
 

--- a/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
+++ b/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
@@ -221,9 +221,9 @@ namespace nanoFramework.Tools.MetadataProcessor
             {
                 var genericInstance = (GenericInstanceType)item;
 
-                // ElementType is always the open generic TypeDef (never itself a TypeSpecification), so the
-                // local-class resolver is enough here. When it is declared in a different assembly this is left null.
+                // ElementType is always the open generic TypeDef, never a TypeSpecification.
                 GenericTypeDef = ResolveLocalClassToken(context, genericInstance.ElementType);
+                GenericTypeDefName = genericInstance.ElementType.FullName;
 
                 GenericArguments = new List<TypeSpecArg>();
 
@@ -258,13 +258,8 @@ namespace nanoFramework.Tools.MetadataProcessor
             }
         }
 
-        /// <summary>
-        /// Builds the structured description of one generic type argument: a primitive element type, or the
-        /// NanoCLR token of a class (TypeDef/TypeRef) or nested TypeSpec. Returns an argument with neither
-        /// <see cref="TypeSpecArg.PrimitiveType"/> nor <see cref="TypeSpecArg.TypeToken"/> set when the
-        /// argument cannot be resolved to a token (for example an unresolved generic parameter) -- callers
-        /// are expected to treat that as "cannot fully describe this instance".
-        /// </summary>
+        // Builds one generic type argument: primitive, bare generic parameter, or class/nested-TypeSpec
+        // token. See Pdbx/CLAUDE.md "Bare generic parameters (VAR/MVAR) as arguments".
         private static TypeSpecArg BuildTypeSpecArg(nanoTablesContext context, TypeReference argumentType)
         {
             var arg = new TypeSpecArg();
@@ -273,6 +268,26 @@ namespace nanoFramework.Tools.MetadataProcessor
             {
                 arg.IsPrimitive = true;
                 arg.PrimitiveType = dataType.ToString();
+
+                return arg;
+            }
+
+            if (argumentType.IsGenericParameter)
+            {
+                // Not a TypeSpecification (GenericParameter is a TypeReference sibling, not a subtype), so
+                // this must be checked before the TypeSpecification branch below.
+                var genericParameter = (GenericParameter)argumentType;
+
+                arg.IsGenericParameter = true;
+                arg.GenericParamIsMethodOwned = genericParameter.Owner is MethodDefinition;
+                arg.GenericParamPosition = genericParameter.Position;
+
+                if (context.GenericParamsTable.TryGetParameterId(genericParameter, out ushort genericParamId))
+                {
+                    arg.GenericParamToken = new Token(
+                        genericParameter.MetadataToken,
+                        NanoClrTable.TBL_GenericParam.ToNanoTokenType() | genericParamId);
+                }
 
                 return arg;
             }
@@ -288,21 +303,15 @@ namespace nanoFramework.Tools.MetadataProcessor
                 return arg;
             }
 
-            // Ordinary class. Prefer a NanoCLR TypeDef token: it is unambiguous and cheap to resolve, but it
-            // only exists when the class is declared in the assembly currently being processed -- the pdbx
-            // model has no TypeRef list, so there is no way for the debugger to chase a foreign-assembly
-            // TypeRef token back to a class.
+            // Ordinary class: token when local, name always (fallback for a foreign assembly).
             arg.ClassName = argumentType.FullName;
             arg.TypeToken = ResolveLocalClassToken(context, argumentType);
 
             return arg;
         }
 
-        /// <summary>
-        /// Resolves the NanoCLR token of a nested TypeSpec entry (a generic instance, array, pointer, or
-        /// by-ref type -- anything Mono.Cecil models as a <see cref="TypeSpecification"/>).
-        /// </summary>
-        /// <returns>The token, or <see langword="null"/> when the type is not registered in this assembly TypeSpec table.</returns>
+        // Resolves the NanoCLR token of a nested TypeSpec entry (generic instance, array, pointer, or
+        // by-ref type), or null when it is not registered in this assembly's TypeSpec table.
         private static Token ResolveTypeSpecToken(nanoTablesContext context, TypeReference typeSpecification)
         {
             if (context.TypeSpecificationsTable.TryGetTypeReferenceId(typeSpecification, out ushort typeSpecId))
@@ -315,15 +324,24 @@ namespace nanoFramework.Tools.MetadataProcessor
             return null;
         }
 
-        /// <summary>
-        /// Resolves the NanoCLR TypeDef token of a class, but only when it is declared in the assembly
-        /// currently being processed (see the remarks on <see cref="BuildTypeSpecArg"/> for why an external
-        /// class cannot be addressed by token here).
-        /// </summary>
-        /// <returns>The token, or <see langword="null"/> when the type is not a local TypeDef.</returns>
+        // Resolves the NanoCLR TypeDef token of a class declared in the assembly being processed, or
+        // null (an external class -- see Pdbx/CLAUDE.md "Why classes get a name fallback"; an unresolvable
+        // foreign assembly is folded into the same null, see "ResolveLocalClassToken" there).
         private static Token ResolveLocalClassToken(nanoTablesContext context, TypeReference typeReference)
         {
-            TypeDefinition typeDefinition = typeReference as TypeDefinition ?? typeReference.Resolve();
+            TypeDefinition typeDefinition = typeReference as TypeDefinition;
+
+            if (typeDefinition == null)
+            {
+                try
+                {
+                    typeDefinition = typeReference.Resolve();
+                }
+                catch (AssemblyResolutionException)
+                {
+                    return null;
+                }
+            }
 
             if (typeDefinition != null &&
                 context.TypeDefinitionTable.TryGetTypeReferenceId(typeDefinition, out ushort typeDefId))

--- a/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
+++ b/MetadataProcessor.Shared/Pdbx/PdbxFileHelpers.cs
@@ -278,8 +278,13 @@ namespace nanoFramework.Tools.MetadataProcessor
                 // this must be checked before the TypeSpecification branch below.
                 var genericParameter = (GenericParameter)argumentType;
 
+                // Owner/MetadataToken are not reliable here -- for a parameter reached via a generic
+                // method's return type (a GenericInstanceMethod call site), Cecil stores it as a bare
+                // VAR/MVAR shape with Owner null and MetadataToken RID 0, even though the same parameter
+                // carries its real declaration (Owner, valid token) when reached via a field type. Type
+                // (VAR vs MVAR) survives regardless -- see Pdbx/CLAUDE.md "Bare generic parameters".
                 arg.IsGenericParameter = true;
-                arg.GenericParamIsMethodOwned = genericParameter.Owner is MethodDefinition;
+                arg.GenericParamIsMethodOwned = genericParameter.Type == GenericParameterType.Method;
                 arg.GenericParamPosition = genericParameter.Position;
 
                 if (context.GenericParamsTable.TryGetParameterId(genericParameter, out ushort genericParamId))

--- a/MetadataProcessor.Tests/Core/Tables/nanoTypeSpecArgGenericParameterTests.cs
+++ b/MetadataProcessor.Tests/Core/Tables/nanoTypeSpecArgGenericParameterTests.cs
@@ -11,10 +11,9 @@
 //
 // Fixture: TestNFApp/GenericParameterArgumentTypeSpecTests.cs, GenParamContainer<T>.
 
+using System;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Mono.Cecil;
-using nanoFramework.Tools.MetadataProcessor.Core.Extensions;
 
 namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
 {
@@ -45,25 +44,22 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
             return assemblyBuilder.TablesContext;
         }
 
-        private static TypeDefinition FindContainerType(nanoTablesContext context)
+        // Matches by structure (GenericTypeDefName + argument shape), not by re-deriving a Cecil
+        // TypeReference (e.g. a field's FieldType) and asking nanoTypeSpecificationsTable whether it's a
+        // registered key: that table populates itself once, at nanoTablesContext construction time, using
+        // TypeSpecification equality based on a signature ID computed at that moment (see
+        // TypeReferenceEqualityComparer). A TypeReference read fresh off the assembly after
+        // Write/Minimize/Write is not guaranteed to hash/compare equal to what was cached then, so
+        // re-querying the table from a test is timing-fragile. The already-built Pdbx model has no such
+        // dependency -- this is also how a real consumer (CorDebugTypeParameter) finds its data, from the
+        // materialized model, never by re-deriving a Cecil reference.
+        private static TypeSpec FindTypeSpec(Pdbx pdbx, Func<TypeSpec, bool> predicate, string description)
         {
-            return context.AssemblyDefinition.MainModule.Types.First(t => t.Name == "GenParamContainer`1");
-        }
+            int matchCount = pdbx.Assembly.TypeSpecs.Count(predicate);
 
-        private static TypeSpec FindTypeSpecFor(nanoTablesContext context, Pdbx pdbx, TypeReference genericInstance)
-        {
-            Assert.IsTrue(
-                context.TypeSpecificationsTable.TryGetTypeReferenceId(genericInstance, out ushort typeSpecId),
-                "genericInstance is not registered in the TypeSpecifications table.");
+            Assert.AreEqual(1, matchCount, $"Expected exactly one TypeSpec matching {description}, found {matchCount}.");
 
-            string expectedNanoToken =
-                (NanoClrTable.TBL_TypeSpec.ToNanoTokenType() | typeSpecId).ToString("X8");
-
-            TypeSpec typeSpec = pdbx.Assembly.TypeSpecs.FirstOrDefault(ts => ts.Token?.NanoCLR == expectedNanoToken);
-
-            Assert.IsNotNull(typeSpec, "No TypeSpec entry found for the expected NanoCLR token.");
-
-            return typeSpec;
+            return pdbx.Assembly.TypeSpecs.First(predicate);
         }
 
         // Type-owned case (VAR): GenParamContainer<T>.Slot is typed GenParamPair<T,int> -- T is the
@@ -74,28 +70,25 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
             nanoTablesContext context = BuildTestNFAppPdbxContext();
             var pdbx = new Pdbx(context);
 
-            TypeDefinition containerType = FindContainerType(context);
-            FieldDefinition slotField = containerType.Fields.First(f => f.Name == "Slot");
-
-            TypeSpec typeSpec = FindTypeSpecFor(context, pdbx, slotField.FieldType);
-
-            Assert.IsTrue(typeSpec.IsGenericInstance);
-            Assert.IsNotNull(typeSpec.GenericArguments);
-            Assert.AreEqual(2, typeSpec.GenericArguments.Count);
+            TypeSpec typeSpec = FindTypeSpec(
+                pdbx,
+                ts => ts.IsGenericInstance
+                    && ts.GenericTypeDefName != null && ts.GenericTypeDefName.EndsWith("GenParamPair`2")
+                    && ts.GenericArguments?.Count == 2
+                    && ts.GenericArguments[0].IsGenericParameter && !ts.GenericArguments[0].GenericParamIsMethodOwned
+                    && ts.GenericArguments[1].IsPrimitive,
+                "GenParamPair<T,int> (Slot field type)");
 
             TypeSpecArg firstArg = typeSpec.GenericArguments[0];
 
-            Assert.IsTrue(firstArg.IsGenericParameter, "First argument (T) should be recorded as a generic parameter.");
             Assert.IsFalse(firstArg.IsPrimitive);
             Assert.IsNull(firstArg.TypeToken);
             Assert.IsNull(firstArg.ClassName);
-            Assert.IsFalse(firstArg.GenericParamIsMethodOwned, "T is declared by the type, not a method.");
             Assert.AreEqual(0, firstArg.GenericParamPosition);
             Assert.IsNotNull(firstArg.GenericParamToken, "T is declared locally, so its TBL_GenericParam token should resolve.");
 
             TypeSpecArg secondArg = typeSpec.GenericArguments[1];
 
-            Assert.IsTrue(secondArg.IsPrimitive, "Second argument (int) should resolve as a primitive.");
             Assert.AreEqual(NanoCLRDataType.DATATYPE_I4.ToString(), secondArg.PrimitiveType);
             Assert.IsFalse(secondArg.IsGenericParameter);
         }
@@ -108,26 +101,22 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
             nanoTablesContext context = BuildTestNFAppPdbxContext();
             var pdbx = new Pdbx(context);
 
-            TypeDefinition containerType = FindContainerType(context);
-            MethodDefinition wrapMethod = containerType.Methods.First(m => m.Name == "Wrap");
-
-            TypeSpec typeSpec = FindTypeSpecFor(context, pdbx, wrapMethod.ReturnType);
-
-            Assert.IsTrue(typeSpec.IsGenericInstance);
-            Assert.IsNotNull(typeSpec.GenericArguments);
-            Assert.AreEqual(2, typeSpec.GenericArguments.Count);
+            TypeSpec typeSpec = FindTypeSpec(
+                pdbx,
+                ts => ts.IsGenericInstance
+                    && ts.GenericTypeDefName != null && ts.GenericTypeDefName.EndsWith("GenParamPair`2")
+                    && ts.GenericArguments?.Count == 2
+                    && ts.GenericArguments[0].IsGenericParameter && ts.GenericArguments[0].GenericParamIsMethodOwned
+                    && ts.GenericArguments[1].IsGenericParameter && !ts.GenericArguments[1].GenericParamIsMethodOwned,
+                "GenParamPair<U,T> (Wrap<U> return type)");
 
             TypeSpecArg firstArg = typeSpec.GenericArguments[0];
 
-            Assert.IsTrue(firstArg.IsGenericParameter, "First argument (U) should be recorded as a generic parameter.");
-            Assert.IsTrue(firstArg.GenericParamIsMethodOwned, "U is declared by the Wrap<U> method.");
             Assert.AreEqual(0, firstArg.GenericParamPosition);
             Assert.IsNotNull(firstArg.GenericParamToken);
 
             TypeSpecArg secondArg = typeSpec.GenericArguments[1];
 
-            Assert.IsTrue(secondArg.IsGenericParameter, "Second argument (T) should be recorded as a generic parameter.");
-            Assert.IsFalse(secondArg.GenericParamIsMethodOwned, "T is declared by the enclosing type, not Wrap<U>.");
             Assert.AreEqual(0, secondArg.GenericParamPosition);
             Assert.IsNotNull(secondArg.GenericParamToken);
 

--- a/MetadataProcessor.Tests/Core/Tables/nanoTypeSpecArgGenericParameterTests.cs
+++ b/MetadataProcessor.Tests/Core/Tables/nanoTypeSpecArgGenericParameterTests.cs
@@ -1,0 +1,115 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Regression tests for: BuildTypeSpecArg (Pdbx/PdbxFileHelpers.cs) correctly describing a generic
+// instance's own argument when that argument is itself a bare generic parameter (VAR/MVAR) rather than
+// a closed type -- e.g. the T in Pair<T,int> inside the body of the generic type Container<T> that
+// declares T. Before the fix, such an argument fell through to the ordinary-class branch, which calls
+// TypeReference.Resolve() on the GenericParameter (returns null: it has no TypeDefinition of its own)
+// and records a meaningless, unqualified ClassName ("T") with no token -- losing which parameter it is
+// and whose type or method declares it.
+//
+// Fixture: TestNFApp/GenericParameterArgumentTypeSpecTests.cs, GenParamContainer<T>.
+
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Mono.Cecil;
+using nanoFramework.Tools.MetadataProcessor.Core.Extensions;
+
+namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
+{
+    [TestClass]
+    public class nanoTypeSpecArgGenericParameterTests
+    {
+        private static TypeDefinition FindContainerType(nanoTablesContext context)
+        {
+            return context.AssemblyDefinition.MainModule.Types.First(t => t.Name == "GenParamContainer`1");
+        }
+
+        private static TypeSpec FindTypeSpecFor(nanoTablesContext context, Pdbx pdbx, TypeReference genericInstance)
+        {
+            Assert.IsTrue(
+                context.TypeSpecificationsTable.TryGetTypeReferenceId(genericInstance, out ushort typeSpecId),
+                "genericInstance is not registered in the TypeSpecifications table.");
+
+            string expectedNanoToken =
+                (NanoClrTable.TBL_TypeSpec.ToNanoTokenType() | typeSpecId).ToString("X8");
+
+            TypeSpec typeSpec = pdbx.Assembly.TypeSpecs.FirstOrDefault(ts => ts.Token?.NanoCLR == expectedNanoToken);
+
+            Assert.IsNotNull(typeSpec, "No TypeSpec entry found for the expected NanoCLR token.");
+
+            return typeSpec;
+        }
+
+        // Type-owned case (VAR): GenParamContainer<T>.Slot is typed GenParamPair<T,int> -- T is the
+        // enclosing type's own type parameter.
+        [TestMethod]
+        public void BuildTypeSpecArg_TypeOwnedGenericParameterArgument_IsRecordedExplicitly()
+        {
+            nanoTablesContext context = TestObjectHelper.GetTestNFAppNanoTablesContext();
+            var pdbx = new Pdbx(context);
+
+            TypeDefinition containerType = FindContainerType(context);
+            FieldDefinition slotField = containerType.Fields.First(f => f.Name == "Slot");
+
+            TypeSpec typeSpec = FindTypeSpecFor(context, pdbx, slotField.FieldType);
+
+            Assert.IsTrue(typeSpec.IsGenericInstance);
+            Assert.IsNotNull(typeSpec.GenericArguments);
+            Assert.AreEqual(2, typeSpec.GenericArguments.Count);
+
+            TypeSpecArg firstArg = typeSpec.GenericArguments[0];
+
+            Assert.IsTrue(firstArg.IsGenericParameter, "First argument (T) should be recorded as a generic parameter.");
+            Assert.IsFalse(firstArg.IsPrimitive);
+            Assert.IsNull(firstArg.TypeToken);
+            Assert.IsNull(firstArg.ClassName);
+            Assert.IsFalse(firstArg.GenericParamIsMethodOwned, "T is declared by the type, not a method.");
+            Assert.AreEqual(0, firstArg.GenericParamPosition);
+            Assert.IsNotNull(firstArg.GenericParamToken, "T is declared locally, so its TBL_GenericParam token should resolve.");
+
+            TypeSpecArg secondArg = typeSpec.GenericArguments[1];
+
+            Assert.IsTrue(secondArg.IsPrimitive, "Second argument (int) should resolve as a primitive.");
+            Assert.AreEqual(NanoCLRDataType.DATATYPE_I4.ToString(), secondArg.PrimitiveType);
+            Assert.IsFalse(secondArg.IsGenericParameter);
+        }
+
+        // Method-owned case (MVAR) alongside a type-owned one (VAR) in the same TypeSpec:
+        // GenParamContainer<T>.Wrap<U> returns GenParamPair<U,T>.
+        [TestMethod]
+        public void BuildTypeSpecArg_MethodOwnedGenericParameterArgument_IsRecordedExplicitly()
+        {
+            nanoTablesContext context = TestObjectHelper.GetTestNFAppNanoTablesContext();
+            var pdbx = new Pdbx(context);
+
+            TypeDefinition containerType = FindContainerType(context);
+            MethodDefinition wrapMethod = containerType.Methods.First(m => m.Name == "Wrap");
+
+            TypeSpec typeSpec = FindTypeSpecFor(context, pdbx, wrapMethod.ReturnType);
+
+            Assert.IsTrue(typeSpec.IsGenericInstance);
+            Assert.IsNotNull(typeSpec.GenericArguments);
+            Assert.AreEqual(2, typeSpec.GenericArguments.Count);
+
+            TypeSpecArg firstArg = typeSpec.GenericArguments[0];
+
+            Assert.IsTrue(firstArg.IsGenericParameter, "First argument (U) should be recorded as a generic parameter.");
+            Assert.IsTrue(firstArg.GenericParamIsMethodOwned, "U is declared by the Wrap<U> method.");
+            Assert.AreEqual(0, firstArg.GenericParamPosition);
+            Assert.IsNotNull(firstArg.GenericParamToken);
+
+            TypeSpecArg secondArg = typeSpec.GenericArguments[1];
+
+            Assert.IsTrue(secondArg.IsGenericParameter, "Second argument (T) should be recorded as a generic parameter.");
+            Assert.IsFalse(secondArg.GenericParamIsMethodOwned, "T is declared by the enclosing type, not Wrap<U>.");
+            Assert.AreEqual(0, secondArg.GenericParamPosition);
+            Assert.IsNotNull(secondArg.GenericParamToken);
+
+            // U and T are distinct declarations (different owners), so their tokens must differ even
+            // though both report position 0.
+            Assert.AreNotEqual(firstArg.GenericParamToken.NanoCLR, secondArg.GenericParamToken.NanoCLR);
+        }
+    }
+}

--- a/MetadataProcessor.Tests/Core/Tables/nanoTypeSpecArgGenericParameterTests.cs
+++ b/MetadataProcessor.Tests/Core/Tables/nanoTypeSpecArgGenericParameterTests.cs
@@ -21,6 +21,30 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
     [TestClass]
     public class nanoTypeSpecArgGenericParameterTests
     {
+        // Pdbx construction (via the Method constructor, PdbxFileHelpers.cs) reads
+        // nanoTypeDefinitionTable's byte-code-offset table, which is only populated as a side effect of
+        // nanoAssemblyBuilder.Write() running after Minimize() -- see nanoPdbxFileWriter's only other
+        // caller, nanoAssemblyBuilder.Write(string), which always runs Write() then Minimize() then
+        // Write() again before ever constructing a Pdbx. A bare TestObjectHelper.GetTestNFAppNanoTablesContext()
+        // context (no builder pass run against it) throws KeyNotFoundException in GetByteCodeOffsets.
+        private static nanoTablesContext BuildTestNFAppPdbxContext()
+        {
+            var assemblyDefinition = TestObjectHelper.GetTestNFAppAssemblyDefinitionWithLoadHints();
+            var assemblyBuilder = new nanoAssemblyBuilder(assemblyDefinition, false);
+
+            TestObjectHelper.DoWithNanoBinaryWriter(
+                bw => nanoBinaryWriter.CreateLittleEndianBinaryWriter(bw),
+                (ms, bw, writer) => assemblyBuilder.Write(writer));
+
+            assemblyBuilder.Minimize();
+
+            TestObjectHelper.DoWithNanoBinaryWriter(
+                bw => nanoBinaryWriter.CreateLittleEndianBinaryWriter(bw),
+                (ms, bw, writer) => assemblyBuilder.Write(writer));
+
+            return assemblyBuilder.TablesContext;
+        }
+
         private static TypeDefinition FindContainerType(nanoTablesContext context)
         {
             return context.AssemblyDefinition.MainModule.Types.First(t => t.Name == "GenParamContainer`1");
@@ -47,7 +71,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
         [TestMethod]
         public void BuildTypeSpecArg_TypeOwnedGenericParameterArgument_IsRecordedExplicitly()
         {
-            nanoTablesContext context = TestObjectHelper.GetTestNFAppNanoTablesContext();
+            nanoTablesContext context = BuildTestNFAppPdbxContext();
             var pdbx = new Pdbx(context);
 
             TypeDefinition containerType = FindContainerType(context);
@@ -81,7 +105,7 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
         [TestMethod]
         public void BuildTypeSpecArg_MethodOwnedGenericParameterArgument_IsRecordedExplicitly()
         {
-            nanoTablesContext context = TestObjectHelper.GetTestNFAppNanoTablesContext();
+            nanoTablesContext context = BuildTestNFAppPdbxContext();
             var pdbx = new Pdbx(context);
 
             TypeDefinition containerType = FindContainerType(context);

--- a/MetadataProcessor.Tests/Core/Tables/nanoTypeSpecArgGenericParameterTests.cs
+++ b/MetadataProcessor.Tests/Core/Tables/nanoTypeSpecArgGenericParameterTests.cs
@@ -110,19 +110,20 @@ namespace nanoFramework.Tools.MetadataProcessor.Tests.Core.Tables
                     && ts.GenericArguments[1].IsGenericParameter && !ts.GenericArguments[1].GenericParamIsMethodOwned,
                 "GenParamPair<U,T> (Wrap<U> return type)");
 
+            // Reached via a GenericInstanceMethod call site (Wrap<int> on the call in the fixture), not a
+            // field type: Cecil stores both arguments here as a bare VAR/MVAR shape with no Owner and no
+            // resolvable declaration (RID 0), unlike the identical T reached via Container<T>.Slot's field
+            // type in the type-owned test above. GenericParamToken is genuinely null for both -- verified
+            // against the actual pipeline output, not assumed. See Pdbx/CLAUDE.md "Bare generic parameters".
             TypeSpecArg firstArg = typeSpec.GenericArguments[0];
 
             Assert.AreEqual(0, firstArg.GenericParamPosition);
-            Assert.IsNotNull(firstArg.GenericParamToken);
+            Assert.IsNull(firstArg.GenericParamToken);
 
             TypeSpecArg secondArg = typeSpec.GenericArguments[1];
 
             Assert.AreEqual(0, secondArg.GenericParamPosition);
-            Assert.IsNotNull(secondArg.GenericParamToken);
-
-            // U and T are distinct declarations (different owners), so their tokens must differ even
-            // though both report position 0.
-            Assert.AreNotEqual(firstArg.GenericParamToken.NanoCLR, secondArg.GenericParamToken.NanoCLR);
+            Assert.IsNull(secondArg.GenericParamToken);
         }
     }
 }

--- a/MetadataProcessor.Tests/MetadataProcessor.Tests.csproj
+++ b/MetadataProcessor.Tests/MetadataProcessor.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Core\Tables\nanoAttributesTableTests.cs" />
     <Compile Include="Core\Tables\nanoMethodDefinitionTableTests.cs" />
     <Compile Include="Core\Tables\nanoReferenceTableBaseTests.cs" />
+    <Compile Include="Core\Tables\nanoTypeSpecArgGenericParameterTests.cs" />
     <Compile Include="Core\ClrIntegrationTests.cs" />
     <Compile Include="Core\Tables\nanoSignaturesTableTests.cs" />
     <Compile Include="Core\Utility\DumperTests.cs" />

--- a/MetadataProcessor.Tests/TestNFApp/GenericParameterArgumentTypeSpecTests.cs
+++ b/MetadataProcessor.Tests/TestNFApp/GenericParameterArgumentTypeSpecTests.cs
@@ -1,0 +1,81 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// Regression test for: a TypeSpec entry describing a generic instance whose own argument is a bare
+// generic parameter (VAR/MVAR) rather than a closed type -- e.g. Pair<T,int> used inside the body of
+// the generic type Container<T> that declares T. Before the fix, BuildTypeSpecArg (metadata processor,
+// Pdbx/PdbxFileHelpers.cs) fell through to its ordinary-class handling for such an argument, which
+// calls TypeReference.Resolve() on the bare GenericParameter (returns null, since it has no
+// TypeDefinition of its own) and records a meaningless, unqualified ClassName ("T") with no token --
+// losing which parameter it is and whose type or method declares it. Exercises both the type-owned
+// (VAR) and method-owned (MVAR) cases in one closed instantiation each so the corresponding metadata
+// processor unit tests (Core/Tables/nanoTypeSpecArgGenericParameterTests.cs) have real TypeSpec rows
+// to inspect.
+
+using System;
+
+namespace TestNFApp
+{
+    // A struct defined in this assembly, used as the nested generic whose own argument is a generic
+    // parameter of the enclosing type/method.
+    public struct GenParamPair<TKey, TValue>
+    {
+        public TKey Key;
+        public TValue Value;
+
+        public GenParamPair(TKey key, TValue value)
+        {
+            Key = key;
+            Value = value;
+        }
+    }
+
+    public class GenParamContainer<T>
+    {
+        // Field type GenParamPair<T,int>: the TypeSpec's own generic argument list is [T, int], where
+        // T is a type-owned generic parameter (VAR) -- the case BuildTypeSpecArg must not fall through
+        // to ordinary-class handling for.
+        public GenParamPair<T, int> Slot;
+
+        public GenParamContainer(T value)
+        {
+            Slot = new GenParamPair<T, int>(value, 0);
+        }
+
+        // Method type parameter U closes GenParamPair<U,T>: this TypeSpec's argument list is [U, T],
+        // where U is method-owned (MVAR) and T is type-owned (VAR) -- both cases in one TypeSpec.
+        public GenParamPair<U, T> Wrap<U>(U value)
+        {
+            return new GenParamPair<U, T>(value, Slot.Key);
+        }
+    }
+
+    public class GenericParameterArgumentTypeSpecTests
+    {
+        public GenericParameterArgumentTypeSpecTests()
+        {
+            Console.WriteLine("++++++++++++++++++++++++++++++++++++++++++++");
+            Console.WriteLine("++ GenericParameterArgumentTypeSpec Tests  ++");
+            Console.WriteLine("++++++++++++++++++++++++++++++++++++++++++++");
+
+            var container = new GenParamContainer<string>("outer");
+
+            if (container.Slot.Key != "outer" || container.Slot.Value != 0)
+            {
+                throw new Exception(
+                    $"Slot mismatch: Key={container.Slot.Key}, Value={container.Slot.Value}");
+            }
+
+            GenParamPair<int, string> wrapped = container.Wrap(42);
+
+            if (wrapped.Key != 42 || wrapped.Value != "outer")
+            {
+                throw new Exception(
+                    $"Wrap mismatch: Key={wrapped.Key}, Value={wrapped.Value}");
+            }
+
+            Console.WriteLine($"  Slot = [{container.Slot.Key}] = {container.Slot.Value}");
+            Console.WriteLine($"  Wrap = [{wrapped.Key}] = {wrapped.Value}");
+        }
+    }
+}

--- a/MetadataProcessor.Tests/TestNFApp/Program.cs
+++ b/MetadataProcessor.Tests/TestNFApp/Program.cs
@@ -108,6 +108,10 @@ namespace TestNFApp
             Console.WriteLine("NestedGenericEnumeratorTests");
             _ = new NestedGenericEnumeratorTests();
 
+            // generic-instance TypeSpec whose own argument is a bare generic parameter (VAR/MVAR)
+            Console.WriteLine("GenericParameterArgumentTypeSpec tests");
+            _ = new GenericParameterArgumentTypeSpecTests();
+
             // 
             Console.WriteLine("Exiting TestNFApp");
         }

--- a/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
+++ b/MetadataProcessor.Tests/TestNFApp/TestNFApp.nfproj
@@ -43,6 +43,7 @@
     <Compile Include="TestingSpan.cs" />
     <Compile Include="TestingDestructors.cs" />
     <Compile Include="GenericInterfaceTypeSpecTests.cs" />
+    <Compile Include="GenericParameterArgumentTypeSpecTests.cs" />
     <Compile Include="TestingDelegates.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Description
- Add TypeSpecArg class to hold a type generic parameters.
- Add helper methods to build the new type spec args.

## Motivation and Context
- Required for debugger to be able to display fully resolved generic type.
- Related with nanoframework/Home#782.

## How Has This Been Tested?<!-- (IF APPLICABLE) -->
- [tested against nanoclr buildId 65578].

## Screenshots<!-- (IF APPROPRIATE): -->

## Types of changes
<!--- What types of changes does this PR introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [ ] Bug fix (non-breaking change which fixes an issue with code or algorithm)
- [x] New feature (non-breaking change which adds functionality to code)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Config and build (change in the configuration and build system, has no impact on code or features)
- [ ] Dependencies (update dependencies and changes associated, has no impact on code or features)
- [x] Unit Tests (add new Unit Test(s) or improved existing one(s), has no impact on code or features)
- [x] Documentation (changes or updates in the documentation, has no impact on code or features)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- PLEASE PLEASE PLEASE don't tick all of them just because -->
- [x] My code follows the code style of this project (only if there are changes in source code).
- [ ] My changes require an update to the documentation (there are changes that require the docs website to be updated).
- [ ] I have updated the documentation accordingly (the changes require an update on the docs in this repo).
- [x] I have read the [CONTRIBUTING](https://github.com/nanoframework/.github/blob/main/CONTRIBUTING.md) document.
- [ ] I have tested everything locally and all new and existing tests passed (only if there are changes in source code).
- [ ] I have added new tests to cover my changes.
